### PR TITLE
Native Additions

### DIFF
--- a/AnoMech/Core/Map/DirectorFunctions.cs
+++ b/AnoMech/Core/Map/DirectorFunctions.cs
@@ -152,4 +152,12 @@ internal static unsafe class DirectorFunctions
 
         DirectorUnknownUpdateFunction(eventFramework, instanceDirector->Info.EventId.Id, sequence, unk, unionData, 12); // Size 12 is hard-coded in the game .exe
     }
+
+    internal static void DirectorUnknownUpdate(byte sequence, byte unk, byte[] unionData)
+    {
+        fixed (byte* unionDataPtr = unionData)
+        {
+            DirectorUnknownUpdate(0, 1, unionDataPtr);
+        }
+    }
 }

--- a/AnoMech/Core/Map/DirectorFunctions.cs
+++ b/AnoMech/Core/Map/DirectorFunctions.cs
@@ -20,12 +20,20 @@ internal static unsafe class DirectorFunctions
 
     private static readonly ProcessDirectorUpdateDelegate processDirectorUpdate;
 
+    private delegate void DirectorUnknownUpdateDelegate(EventFramework* eventFramework, uint eventId, byte sequence, byte unk, byte* unionData, ulong size);
+    private static readonly DirectorUnknownUpdateDelegate DirectorUnknownUpdateFunction;
+
     static DirectorFunctions()
     {
         var addr = Plugin.SigScanner.ScanText(
             "40 53 57 48 83 EC 58 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 44 24 ?? 41 8B F9");
         processDirectorUpdate =
             Marshal.GetDelegateForFunctionPointer<ProcessDirectorUpdateDelegate>(addr);
+
+        var unknownUpdateAddr = Plugin.SigScanner.ScanText(
+            "89 54 24 10 48 89 4C 24 ?? 53 56 57 41 55 41 57 48 83 EC 30 48 8B 99");
+        DirectorUnknownUpdateFunction = Marshal.GetDelegateForFunctionPointer<DirectorUnknownUpdateDelegate>(unknownUpdateAddr);
+
         Plugin.Log.Information("[DirectorFunctions] Initialized.");
     }
 
@@ -129,5 +137,19 @@ internal static unsafe class DirectorFunctions
         if (disabled > 0)
             Plugin.Log.Information($"[BarrierDrop] disabled {disabled} SharedGroups within r{radius} of ({center.X:F2},{center.Y:F2},{center.Z:F2})");
         return disabled;
+    }
+
+    internal static void DirectorUnknownUpdate(byte sequence, byte unk, byte* unionData)
+    {
+        var eventFramework = EventFramework.Instance();
+        var instanceDirector = eventFramework->GetInstanceContentDirector();
+
+        if (instanceDirector == null)
+        {
+            Plugin.Log.Debug("[DirectorFunctions] DirectorUnknownUpdate: no InstanceContentDirector, skipping.");
+            return;
+        }
+
+        DirectorUnknownUpdateFunction(eventFramework, instanceDirector->Info.EventId.Id, sequence, unk, unionData, 12); // Size 12 is hard-coded in the game .exe
     }
 }

--- a/AnoMech/Core/MathUtil.cs
+++ b/AnoMech/Core/MathUtil.cs
@@ -14,4 +14,14 @@ internal static class MathUtil
         if (r <= -MathF.PI) r = MathF.PI;
         return r;
     }
+
+    public static ushort QuantizeRotation(float degrees)
+    {
+        return (ushort)((degrees + MathF.PI) / (2 * MathF.PI) * ushort.MaxValue);
+    }
+
+    public static ushort QuantizePosition(float value)
+    {
+        return (ushort)((value + 1000) * 100 * 0.32767f);
+    }
 }

--- a/AnoMech/Core/Native/ActorCastFunctions.cs
+++ b/AnoMech/Core/Native/ActorCastFunctions.cs
@@ -34,7 +34,7 @@ internal static unsafe class ActorCastFunctions
         HandleActorCastPacketFunction =
             Marshal.GetDelegateForFunctionPointer<HandleActorCastPacketDelegate>(addr);
 
-        Plugin.Log.Information("[DirectorFunctions] Initialized.");
+        Plugin.Log.Information("[ActorCastFunctions] Initialized.");
     }
 
     internal static void HandleActorCastPacket(uint entityId, ActorCastPacket* packet)

--- a/AnoMech/Core/Native/ActorCastFunctions.cs
+++ b/AnoMech/Core/Native/ActorCastFunctions.cs
@@ -1,0 +1,44 @@
+// https://github.com/aers/FFXIVClientStructs/pull/1855
+using System.Runtime.InteropServices;
+
+namespace AnoMech.Core.Native;
+
+[StructLayout(LayoutKind.Explicit, Size = 0x20)]
+public partial struct ActorCastPacket
+{
+    [FieldOffset(0x00)] public ushort ActionId;
+    [FieldOffset(0x02)] public byte ActionType;
+    [FieldOffset(0x03)] public byte OmenDelay; // The value gets divided by 10.0f
+    [FieldOffset(0x04)] public uint ActionId_2;
+    [FieldOffset(0x08)] public float CastTime;
+    [FieldOffset(0x0C)] public uint TargetEntityId;
+    [FieldOffset(0x10)] public ushort RotationInt; // Quantized Rotation
+    [FieldOffset(0x12)] public bool Interruptible;
+    [FieldOffset(0x14)] public uint BallistaEntityId;
+    [FieldOffset(0x18)] public ushort PositionX; // Quantized Position
+    [FieldOffset(0x1A)] public ushort PositionY; // Quantized Position
+    [FieldOffset(0x1C)] public ushort PositionZ; // Quantized Position
+}
+
+internal static unsafe class ActorCastFunctions
+{
+    private delegate nint HandleActorCastPacketDelegate(uint entityId, ActorCastPacket* packet);
+
+    private static readonly HandleActorCastPacketDelegate HandleActorCastPacketFunction;
+
+    static ActorCastFunctions()
+    {
+        var addr = Plugin.SigScanner.ScanText(
+            "40 53 57 48 81 EC ?? ?? ?? ?? 48 8B FA 8B");
+
+        HandleActorCastPacketFunction =
+            Marshal.GetDelegateForFunctionPointer<HandleActorCastPacketDelegate>(addr);
+
+        Plugin.Log.Information("[DirectorFunctions] Initialized.");
+    }
+
+    internal static void HandleActorCastPacket(uint entityId, ActorCastPacket* packet)
+    {
+        HandleActorCastPacketFunction(entityId, packet);
+    }
+}

--- a/AnoMech/Core/Native/ModelContainerFunctions.cs
+++ b/AnoMech/Core/Native/ModelContainerFunctions.cs
@@ -1,0 +1,25 @@
+using FFXIVClientStructs.FFXIV.Client.Game.Character;
+using System.Runtime.InteropServices;
+
+namespace AnoMech.Core.Native;
+
+internal static unsafe class ModelContainerFunctions
+{
+    // Client::Game::Character::ModelContainer_CalculateUnscaledRadius
+    private delegate float CalculateUnscaledRadiusDelegate(ModelContainer* modelContainer);
+    private static readonly CalculateUnscaledRadiusDelegate CalculateUnscaledRadiusFunction;
+
+    static ModelContainerFunctions()
+    {
+        var addr = Plugin.SigScanner.ScanText(
+            "40 53 48 83 EC 20 48 8B D9 48 8B 49 08 48 8B 01 FF 50 10 83 F8 02");
+
+        CalculateUnscaledRadiusFunction =
+            Marshal.GetDelegateForFunctionPointer<CalculateUnscaledRadiusDelegate>(addr);
+    }
+
+    internal static float CalculateUnscaledRadius(ModelContainer* modelContainer)
+    {
+        return CalculateUnscaledRadiusFunction(modelContainer);
+    }
+}

--- a/AnoMech/Core/Native/ModelContainerFunctions.cs
+++ b/AnoMech/Core/Native/ModelContainerFunctions.cs
@@ -16,6 +16,8 @@ internal static unsafe class ModelContainerFunctions
 
         CalculateUnscaledRadiusFunction =
             Marshal.GetDelegateForFunctionPointer<CalculateUnscaledRadiusDelegate>(addr);
+
+        Plugin.Log.Information("[ModelContainerFunctions] Initialized.");
     }
 
     internal static float CalculateUnscaledRadius(ModelContainer* modelContainer)

--- a/AnoMech/Core/SimObjects/SimCast.cs
+++ b/AnoMech/Core/SimObjects/SimCast.cs
@@ -1,8 +1,10 @@
-using System;
-using System.Numerics;
 using AnoMech.Core.Game;
+using AnoMech.Core.Native;
+using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using System;
+using System.Numerics;
 
 namespace AnoMech.Core.SimObjects;
 
@@ -129,6 +131,92 @@ public sealed unsafe class SimCast : ISimObject
         return true;
     }
 
+    public void NativeCast(uint actionId, ActionType actionType, float omenDelay, float castTime, bool interruptible, float? rotation = null, Vector3? position = null, GameObjectId? targetId = null, GameObjectId? ballistaId = null)
+    {
+        var omenDelayByte = (byte)(omenDelay * 10);
+
+        var rot = rotation ?? parent.Rotation;
+        var qRotation = MathUtil.QuantizeRotation(rot);
+
+        var animationTargetId = targetId == null ? 0xE0000000 : targetId.Value.ObjectId;
+        var ballistaTargetId = ballistaId == null ? 0xE0000000 : ballistaId.Value.ObjectId;
+
+        var localPos = position ?? parent.Position;
+        var globalPos = coordinates.ToGlobal(localPos);
+
+        var qPosX = MathUtil.QuantizePosition(globalPos.X);
+        var qPosY = MathUtil.QuantizePosition(globalPos.Y);
+        var qPosZ = MathUtil.QuantizePosition(globalPos.Z);
+
+        var actorCastPacket = new ActorCastPacket
+        {
+            ActionId = (ushort)actionId,
+            ActionType = (byte)actionType,
+            OmenDelay = omenDelayByte,
+            ActionId_2 = actionId,
+            CastTime = castTime,
+            TargetEntityId = animationTargetId,
+            RotationInt = qRotation,
+            BallistaEntityId = ballistaTargetId,
+            PositionX = qPosX,
+            PositionY = qPosY,
+            PositionZ = qPosZ,
+        };
+
+        ActorCastFunctions.HandleActorCastPacket(parent.GameObjectId.ObjectId, &actorCastPacket);
+    }
+
+    public void NativeActionEffect(uint actionId, float animationLock, ushort spellId, byte animationVariaton, ActionType actionType, byte flags, float? rotation = null, Vector3? position = null, GameObjectId? animationTargetId = null, GameObjectId? actionTargetId = null, GameObjectId? ballistaId = null)
+    {
+        const uint NullObjectId = 0xE0000000;
+
+        var chara = parent.BattleCharaPtr;
+
+        if (chara == null)
+        {
+            return;
+        }
+
+        var nullActionTarget = actionTargetId == null;
+
+        var animationTarget = animationTargetId == null ? new GameObjectId { ObjectId = NullObjectId, Type = 0 } : animationTargetId!.Value;
+        var actionTarget = nullActionTarget ? new GameObjectId { ObjectId = NullObjectId, Type = 0 } : actionTargetId!.Value;
+        var ballistaTarget = ballistaId == null ? NullObjectId : ballistaId.Value.ObjectId;
+
+        var rot = rotation ?? parent.Rotation;
+        var qRotation = MathUtil.QuantizeRotation(rot);
+
+        var localPos = position ?? Vector3.Zero;
+        var globalPos = coordinates.ToGlobal(localPos);
+
+        var header = new ActionEffectHandler.Header
+        {
+            AnimationTargetId = animationTarget,
+            ActionId = actionId,
+            GlobalSequence = 0,
+            AnimationLock = animationLock,
+            BallistaEntityId = ballistaTarget,
+            SourceSequence = 0,
+            RotationInt = qRotation,
+            SpellId = spellId,
+            AnimationVariation = animationVariaton,
+            ActionType = (byte)actionType,
+            Flags = flags,
+            NumTargets = (byte)(nullActionTarget ? 0 : 1)
+        };
+
+        var targetEffects = new ActionEffectHandler.TargetEffects();
+
+        ActionEffectHandler.Receive(
+            parent.GameObjectId.ObjectId,
+            (Character*)chara,
+            &globalPos,
+            &header,
+            &targetEffects,
+            &actionTarget
+            );
+    }
+
     public void Tick(float deltaSeconds)
     {
         omen?.Tick(deltaSeconds);
@@ -244,77 +332,26 @@ public sealed unsafe class SimCast : ISimObject
     // deliver to. When deliverTo is null, NumTargets=0 (used for self-targeted
     // casts and cast releases without an entity target) — the release animation
     // still plays.
-    private static void FireActionEffect(BattleChara* chara, Vector3? targetLocation = null, GameObjectId? deliverTo = null, byte animationVariation = 0)
+    private void FireActionEffect(BattleChara* chara, Vector3? targetLocation = null, GameObjectId? deliverTo = null, byte animationVariation = 0)
     {
         var actionId = chara->CastInfo.ActionId;
 
-        // Engine ApplyAll dereferences whatever LookupBattleCharaByEntityId returns for each
-        // targetEntityIds[i] without a null check. A captured GameObjectId can outlive the
-        // BC behind it (target killed/despawned mid-cast, scenario reset, lifetime expiry),
-        // and a stale id resolves to null in _battleCharas → ApplyAll+0x45 null-deref. Drop
-        // to the no-target path in that case; release animation still plays off casterEntityId.
-        var safeDeliver = deliverTo;
-        if (safeDeliver is { } probeId)
+        if (deliverTo != null)
         {
-            var cm = CharacterManager.Instance();
-            if (cm == null || cm->LookupBattleCharaByEntityId((uint)probeId.Id) == null)
+            var characterManager = CharacterManager.Instance();
+            var deliverToId = deliverTo.Value.ObjectId;
+
+            if (characterManager == null || characterManager->LookupBattleCharaByEntityId(deliverToId) == null)
             {
                 Plugin.Log.Warning(
-                    $"FireActionEffect: target {probeId.Id:X} for action {actionId:X} on caster {chara->EntityId:X} not in CharacterManager._battleCharas; dropping deliverTo to avoid ApplyAll null-deref");
-                safeDeliver = null;
+                    $"FireActionEffect: target {deliverToId:X} for action {actionId:X} on caster {chara->EntityId:X} not in CharacterManager._battleCharas; dropping deliverTo to avoid ApplyAll null-deref");
             }
+
+            deliverTo = null;
         }
-
-        var rotationInt = (ushort)Math.Clamp(
-            (int)((chara->Rotation / MathF.PI) * 32767f + 32767f), 0, 65535);
-
-        // Derive AnimationTargetId from the sanitized delivery state, not from CastInfo.TargetId
-        // (snapshotted at Start() and possibly stale). When there's no valid entity target, use
-        // the benign 0xE0000000 "no target" sentinel — never the caster's own spawned id. Our
-        // spawned BattleCharas get ids in the reserved 0xE0000001+ pronoun range (BattleCharaSpawn),
-        // and Receive/ApplyAll resolves AnimationTargetId through the placeholder resolver with no
-        // accompanying pointer, null-derefing on a reserved id (crash dump 20260529_210128). In solo
-        // mode the boss is the first spawned BC (index 0 -> 0xE0000001), so a self-cast with no
-        // target reliably hit that path. The release animation still plays off casterEntityId.
-        var header = default(ActionEffectHandler.Header);
-        if (safeDeliver is { } sd)
-            header.AnimationTargetId = sd;
-        else
-            header.AnimationTargetId = 0xE0000000;
-        header.ActionId = actionId;
-        header.GlobalSequence = 0;
-        header.AnimationLock = 0f;
-        header.BallistaEntityId = 0xE0000000;
-        header.SourceSequence = 0;
-        header.RotationInt = rotationInt;
-        header.SpellId = (ushort)actionId;
-        header.AnimationVariation = animationVariation;
-        header.ActionType = chara->CastInfo.ActionType;
-        header.NumTargets = (byte)(safeDeliver.HasValue ? 1 : 0);
-        header.ForceAnimationLock = true;
 
         var pos = targetLocation ?? new Vector3(chara->Position.X, chara->Position.Y, chara->Position.Z);
 
-        if (safeDeliver is { } targetId)
-        {
-            var effectsBlock = default(ActionEffectHandler.TargetEffects);
-            ActionEffectHandler.Receive(
-                chara->EntityId,
-                (Character*)chara,
-                &pos,
-                &header,
-                &effectsBlock,
-                &targetId);
-        }
-        else
-        {
-            ActionEffectHandler.Receive(
-                chara->EntityId,
-                (Character*)chara,
-                &pos,
-                &header,
-                null,
-                null);
-        }
+        NativeActionEffect(actionId, 0f, (ushort)actionId, animationVariation, (ActionType)chara->CastInfo.ActionType, 0, chara->Rotation, pos, deliverTo, deliverTo);
     }
 }

--- a/AnoMech/Core/SimObjects/SimCast.cs
+++ b/AnoMech/Core/SimObjects/SimCast.cs
@@ -13,11 +13,10 @@ namespace AnoMech.Core.SimObjects;
 // Character::StartCast) is what lets the simulator replay arbitrary boss
 // abilities; on completion SimCast fires a synthetic ActionEffectHandler.Receive
 // with a server-shaped header so the release animation/VFX play. It owns the
-// cast's SimOmen telegraph and the post-release animation lock that roots the
-// caster.
+// post-release animation lock that roots the caster.
 //
 // One SimCast per caster, constructed once and reused. Start() begins a cast (or
-// fires instantly when the cast time resolves to <= 0); Tick() advances it. The
+// fires instantly when the cast time resolves to <= 0). The
 // owning SimEnemy reads IsCasting/Progress/ActionId for the cast-bar HUD and
 // IsBusy to decide when to root a following boss. All target coordinates handled
 // here are world-space — the SimEnemy adapter converts from scenario-local.
@@ -25,25 +24,17 @@ public sealed unsafe class SimCast : ISimObject
 {
     private readonly SimCharacter parent;
     private readonly Coordinates coordinates;
-    private SimOmen? omen;
 
     private bool casting;
     private float elapsed;
     private float total;
+    private float fireDelay;
+    private float fireDelayElapsed;
     private Vector3? targetLocation;   // scenario-local coords
     private GameObjectId? targetId;
     private byte animationVariation;
 
-    private bool omenScheduled;
-    private float omenDelay;
-    private float omenRotate;
-    private uint omenActionId;
-
-    // Engine doesn't expose post-action animation-lock duration via EXD — the
-    // real value only ships in the server's ActionEffect packet. 0.6s is a
-    // reasonable approximation for most boss abilities; if a scenario needs
-    // tighter timing we can derive per-action values from captured ACT logs.
-    private const float DefaultAnimationLockSeconds = 0.6f;
+    private float animationLock;
     private float remainingAnimationLock;
 
     public bool IsCasting => casting;
@@ -72,62 +63,51 @@ public sealed unsafe class SimCast : ISimObject
     // to world only where native fields demand it) drives the AOE landing point and
     // the pre-fire facing snap; targetId, if set, makes the packet carry NumTargets=1
     // (some actions only animate on the caster when an entity target is delivered).
-    public bool Start(uint actionId, Vector3? localTargetLocation, float? castSeconds, GameObjectId? targetId, float omenDelay, float omenRotate, byte animationVariation)
+    public bool Start(uint actionId, Vector3? localTargetLocation, float? castTime, GameObjectId? targetId, float omenDelay, float rotation, byte animationVariation, float animationLock, float? fireDelay = null)
     {
         var chara = parent.BattleCharaPtr;
         if (chara == null) return false;
 
         Lumina.Excel.Sheets.Action action;
-        if (castSeconds is null)
+
+        if (castTime == null)
         {
             var actionSheet = Plugin.DataManager.GetExcelSheet<Lumina.Excel.Sheets.Action>();
+
             if (!actionSheet.TryGetRow(actionId, out action))
             {
-                Plugin.Log.Warning($"Action row {actionId} not found");
+                Plugin.Log.Warning($"[SimCast.Start] Action Row {actionId} not found");
                 return false;
             }
-            castSeconds = action.Cast100ms / 10f;
+
+            castTime = action.Cast100ms / 10f;
         }
 
-        var seconds = castSeconds.Value;
-        chara->CastInfo.ActionType = 1; // ActionType.Action
-        chara->CastInfo.ActionId = actionId;
-        if (targetId is { } tid)
-            chara->CastInfo.TargetId = tid;
-        else
-            chara->CastInfo.TargetId = chara->GetGameObjectId();
-        if (localTargetLocation is { } loc) chara->CastInfo.TargetLocation = coordinates.ToGlobal(loc);
+        this.animationLock = animationLock;
+        var castTimeValue = castTime.Value;
 
-        targetLocation = localTargetLocation;
-        this.targetId = targetId;
-        this.animationVariation = animationVariation;
-        ActionId = actionId;
-        if (seconds <= 0f)
+        if (castTimeValue <= 0)
         {
             FaceTarget(chara);
-            FireActionEffect(chara, WorldTargetLocation, targetId, animationVariation);
-            remainingAnimationLock = DefaultAnimationLockSeconds;
+            remainingAnimationLock = animationLock;
+            FireActionEffect(chara, actionId, WorldTargetLocation, targetId, animationVariation, animationLock);
             ResetCastState();
             return true;
         }
 
-        chara->CastInfo.IsCasting = true;
-        chara->CastInfo.Interruptible = false;
-        chara->CastInfo.CurrentCastTime = 0f;
-        chara->CastInfo.BaseCastTime = seconds;
-        chara->CastInfo.TotalCastTime = seconds;
+        var target = targetId ?? chara->GetGameObjectId();
+        NativeCast(actionId, ActionType.Action, omenDelay, castTimeValue, false, rotation, localTargetLocation, target);
+
+        elapsed = 0f;
+        total = chara->CastInfo.TotalCastTime;
 
         casting = true;
-        elapsed = 0f;
-        total = seconds;
-        omenScheduled = false;
-        this.omenDelay = MathF.Max(0f, omenDelay);
-        this.omenRotate = omenRotate;
-        omenActionId = actionId;
-        if (this.omenDelay <= 0f)
-            SpawnOmen(chara);
-        else
-            omenScheduled = true;
+        targetLocation = localTargetLocation;
+        this.targetId = targetId;
+        this.animationVariation = animationVariation;
+        ActionId = actionId;
+        this.fireDelay = fireDelay ?? 0;
+
         return true;
     }
 
@@ -219,51 +199,48 @@ public sealed unsafe class SimCast : ISimObject
 
     public void Tick(float deltaSeconds)
     {
-        omen?.Tick(deltaSeconds);
-        if (omen is { IsActive: false })
+        if (remainingAnimationLock > 0f)
         {
-            omen.Despawn();
-            omen = null;
+            remainingAnimationLock = MathF.Max(0f, remainingAnimationLock - deltaSeconds);
         }
 
-        if (remainingAnimationLock > 0f)
-            remainingAnimationLock = MathF.Max(0f, remainingAnimationLock - deltaSeconds);
-
-        if (!casting) return;
+        if (!casting)
+        {
+            return;
+        }
 
         var chara = parent.BattleCharaPtr;
-        if (chara == null) { casting = false; return; }
-
-        elapsed += deltaSeconds;
-        if (omenScheduled && elapsed >= omenDelay)
+        if (chara == null)
         {
-            omenScheduled = false;
-            SpawnOmen(chara);
+            casting = false;
+            return;
         }
+
+        var castInfo = chara->CastInfo;
+        elapsed = castInfo.CurrentCastTime;
+
         if (elapsed >= total)
         {
-            chara->CastInfo.CurrentCastTime = total;
-            FaceTarget(chara);
-            FireActionEffect(chara, WorldTargetLocation, targetId, animationVariation);
-            remainingAnimationLock = DefaultAnimationLockSeconds;
-            chara->CastInfo.IsCasting = false;
-            omen?.Despawn();
-            omen = null;
-            ResetCastState();
-        }
-        else
-        {
-            chara->CastInfo.CurrentCastTime = elapsed;
-        }
-    }
+            var fire = true;
 
-    // Suppress the default telegraph so a scenario can render a custom omen (e.g.
-    // SwivelCannon's 210° cone covers the whole arena from the edge; the scenario
-    // draws a half-disc at arena center instead).
-    public void HideOmen()
-    {
-        omen?.Despawn();
-        omen = null;
+            if (fireDelay > 0)
+            {
+                fireDelayElapsed += deltaSeconds;
+
+                if (fireDelayElapsed < fireDelay)
+                {
+                    fire = false;
+                }
+            }
+
+            if (fire)
+            {
+                FaceTarget(chara);
+                remainingAnimationLock = animationLock;
+                FireActionEffect(chara, ActionId, WorldTargetLocation, targetId, animationVariation, animationLock);
+                ResetCastState();
+            }
+        }
     }
 
     // Teardown for caster despawn: drop the telegraph, stop any pending delayed
@@ -282,35 +259,22 @@ public sealed unsafe class SimCast : ISimObject
             chara->CastInfo.ActionType = 0;
         }
         casting = false;
-        omenScheduled = false;
-        omen?.Despawn();
-        omen = null;
     }
 
     private void ResetCastState()
     {
         casting = false;
-        omenScheduled = false;
         targetLocation = null;
         targetId = null;
         animationVariation = 0;
         ActionId = 0;
+        fireDelay = 0;
+        fireDelayElapsed = 0;
     }
 
     // targetLocation is stored scenario-local; lift to world only for native
     // ActionEffect delivery (Receive / CastInfo expect world coords).
     private Vector3? WorldTargetLocation => targetLocation is { } loc ? coordinates.ToGlobal(loc) : null;
-
-    private void SpawnOmen(BattleChara* chara)
-    {
-        // Origin in scenario-local coords (parent.Position is local); SimOmen converts
-        // to world at its native spawn boundary.
-        var origin = targetLocation ?? parent.Position;
-        var rotation = MathUtil.NormalizeRotation(chara->Rotation + omenRotate);
-        omen?.Despawn();
-        // Persistent (no duration): SimCast clears it on cast completion / hide / despawn.
-        omen = new SimOmen(coordinates, omenActionId, origin, rotation);
-    }
 
     // Targeted casts (ground location now; entity targets later) snap to face the target
     // on the final tick so the release animation plays in the intended direction even if
@@ -332,10 +296,8 @@ public sealed unsafe class SimCast : ISimObject
     // deliver to. When deliverTo is null, NumTargets=0 (used for self-targeted
     // casts and cast releases without an entity target) — the release animation
     // still plays.
-    private void FireActionEffect(BattleChara* chara, Vector3? targetLocation = null, GameObjectId? deliverTo = null, byte animationVariation = 0)
+    private void FireActionEffect(BattleChara* chara, uint actionId, Vector3? targetLocation = null, GameObjectId? deliverTo = null, byte animationVariation = 0, float animationLock = 0f)
     {
-        var actionId = chara->CastInfo.ActionId;
-
         if (deliverTo != null)
         {
             var characterManager = CharacterManager.Instance();
@@ -352,6 +314,6 @@ public sealed unsafe class SimCast : ISimObject
 
         var pos = targetLocation ?? new Vector3(chara->Position.X, chara->Position.Y, chara->Position.Z);
 
-        NativeActionEffect(actionId, 0f, (ushort)actionId, animationVariation, (ActionType)chara->CastInfo.ActionType, 0, chara->Rotation, pos, deliverTo, deliverTo);
+        NativeActionEffect(actionId, animationLock, (ushort)actionId, animationVariation, (ActionType)chara->CastInfo.ActionType, 0, chara->Rotation, pos, deliverTo, deliverTo);
     }
 }

--- a/AnoMech/Core/SimObjects/SimCast.cs
+++ b/AnoMech/Core/SimObjects/SimCast.cs
@@ -137,6 +137,7 @@ public sealed unsafe class SimCast : ISimObject
             CastTime = castTime,
             TargetEntityId = animationTargetId,
             RotationInt = qRotation,
+            Interruptible = interruptible,
             BallistaEntityId = ballistaTargetId,
             PositionX = qPosX,
             PositionY = qPosY,

--- a/AnoMech/Core/SimObjects/SimEnemy.cs
+++ b/AnoMech/Core/SimObjects/SimEnemy.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.Numerics;
 using AnoMech.Core.Game;
 using AnoMech.Core.Native;
+using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using Lumina.Excel.Sheets;
+using System.Collections.Generic;
+using System.Numerics;
 
 namespace AnoMech.Core.SimObjects;
 
@@ -288,6 +288,16 @@ public sealed unsafe class SimEnemy : SimNpc
     {
         // targetLocation stays scenario-local; SimCast lifts to world at native boundaries.
         return cast.Start(actionId, targetLocation, castSeconds, targetId, omenDelay, omenRotate, animationVariation);
+    }
+
+    public void NativeCast(uint actionId, ActionType actionType, float omenDelay, float castTime, bool interruptible, float? rotation = null, Vector3? position = null, GameObjectId? targetId = null, GameObjectId? ballistaId = null)
+    {
+        cast.NativeCast(actionId, actionType, omenDelay, castTime, interruptible, rotation, position, targetId, ballistaId);
+    }
+
+    public void NativeActionEffect(uint actionId, float animationLock, ushort spellId, byte animationVariaton, ActionType actionType, byte flags, float? rotation = null, Vector3? position = null, GameObjectId? animationTargetId = null, GameObjectId? actionTargetId = null, GameObjectId? ballistaId = null)
+    {
+        cast.NativeActionEffect(actionId, animationLock, spellId, animationVariaton, actionType, flags, rotation, position, animationTargetId, actionTargetId, ballistaId);
     }
 
     public override bool AnimationLock => cast.IsBusy;

--- a/AnoMech/Core/SimObjects/SimEnemy.cs
+++ b/AnoMech/Core/SimObjects/SimEnemy.cs
@@ -131,6 +131,14 @@ public sealed unsafe class SimEnemy : SimNpc
             return null;
         }
 
+        var modelCharaId = config.ModelCharaId != 0 ? config.ModelCharaId : bnpc.ModelChara.RowId;
+        var modelCharaSheet = Plugin.DataManager.GetExcelSheet<ModelChara>();
+        if (!modelCharaSheet.TryGetRow(modelCharaId, out var modelChara))
+        {
+            Plugin.Log.Warning($"ModelChara row {config.BNpcBaseId} (0x{config.BNpcBaseId:X}) not found");
+            return null;
+        }
+
         if (!BattleCharaSpawn.CreateBattleChara(out var idx, out var obj)) return null;
 
         var chara = (BattleChara*)obj;
@@ -143,10 +151,33 @@ public sealed unsafe class SimEnemy : SimNpc
         chara->SetRotation(MathUtil.NormalizeRotation(config.Placement.Rotation));
         var scale = config.Scale > 0f ? config.Scale : bnpc.Scale;
         chara->Scale = scale;
-        var modelCharaId = config.ModelCharaId != 0 ? config.ModelCharaId : bnpc.ModelChara.RowId;
         chara->ModelContainer.ModelCharaId = (int)modelCharaId;
         chara->SEPack = bnpc.SEPack;
-        var hitboxRadius = config.HitboxRadius > 0f ? config.HitboxRadius : ResolveHitboxRadius(modelCharaId, scale);
+
+        var nativeHitbox = true;
+
+        // From Client::Game::Character::CharacterSetupContainer_SetupRaw
+        switch (modelChara.Type)
+        {
+            case 1:
+                // TODO: This Type in the game's .exe is a bit complex, for now we just fallback to the previous solving method
+                var hitboxRadius = config.HitboxRadius > 0f ? config.HitboxRadius : ResolveHitboxRadius(modelCharaId, scale);
+                chara->HitboxRadius = hitboxRadius;
+                nativeHitbox = false;
+                break;
+            case 2:
+                chara->ModelContainer.ModelSkeletonId = modelChara.Model + 10000;
+                break;
+            case 3:
+                chara->ModelContainer.ModelSkeletonId = modelChara.Model;
+                break;
+        }
+
+        if (nativeHitbox)
+        {
+            chara->ModelContainer.UnscaledRadius = ModelContainerFunctions.CalculateUnscaledRadius(&chara->ModelContainer);
+            chara->HitboxRadius = chara->Scale * chara->ModelContainer.UnscaledRadius; // From Client::Game::Character::ModelContainer_UpdateHitboxRadius
+        }
 
         // Engine-resolved name (vfunc 6), same source as the nameplate, so the Name[]
         // buffer we stamp below stays consistent with the rest of the UI.
@@ -158,7 +189,6 @@ public sealed unsafe class SimEnemy : SimNpc
         chara->CharacterSetup.CopyFromCharacter((Character*)chara, CharacterSetupContainer.CopyFlags.None);
 
         chara->BattleNpcSubKind = BattleNpcSubKind.Combatant;
-        chara->HitboxRadius = hitboxRadius;
         chara->MaxHealth = 1_000_000;
         chara->Health = 1_000_000;
         chara->Battalion = 4;

--- a/AnoMech/Core/SimObjects/SimEnemy.cs
+++ b/AnoMech/Core/SimObjects/SimEnemy.cs
@@ -313,11 +313,15 @@ public sealed unsafe class SimEnemy : SimNpc
         var draw = obj->DrawObject;
         return draw != null && draw->IsVisible;
     }
-    
-    public bool Cast(uint actionId, Vector3? targetLocation = null, float? castSeconds = null, GameObjectId? targetId = null, float omenDelay = 0f, float omenRotate = 0f, byte animationVariation = 0)
+
+    // Engine doesn't expose post-action animation-lock duration via EXD — the
+    // real value only ships in the server's ActionEffect packet. 0.6s is a
+    // reasonable approximation for most boss abilities; if a scenario needs
+    // tighter timing we can derive per-action values from captured ACT logs.
+    public bool Cast(uint actionId, Vector3? targetLocation = null, float? castSeconds = null, GameObjectId? targetId = null, float omenDelay = 0f, float omenRotate = 0f, byte animationVariation = 0, float animationLock = 0.6f, float? fireDelay = null)
     {
         // targetLocation stays scenario-local; SimCast lifts to world at native boundaries.
-        return cast.Start(actionId, targetLocation, castSeconds, targetId, omenDelay, omenRotate, animationVariation);
+        return cast.Start(actionId, targetLocation, castSeconds, targetId, omenDelay, omenRotate, animationVariation, animationLock, fireDelay);
     }
 
     public void NativeCast(uint actionId, ActionType actionType, float omenDelay, float castTime, bool interruptible, float? rotation = null, Vector3? position = null, GameObjectId? targetId = null, GameObjectId? ballistaId = null)


### PR DESCRIPTION
As the title implies, this adds a little bit of native functions/functionality.

**SimCast** now has two new functions: `NativeCast` and `NativeActionEffect`, which allows for more accurate cast execution. `SimCast.Start` and `FireActionEffect` has been altered to work with these new Native methods, and because `NativeCast` manages the Omen, the property has been dropped. Despite major logic changes, this should not be compatibility breaking for existing code.

**SimEnemy** has the `Spawn` method slightly modified, so that the Unscaled and Hitbox radius are (mostly) properly calculated. A notorious example of the already existing code failing in certain situations is The Ultima Weapon (BNpcBaseId 8734), which creates the correct model at the correct scale, but the hitbox ring is very small. There's a certain type of ModelChara that's a bit more complex in the game's code and hasn't been included in here, so for that the previous solving method is used.
Also, the new Cast methods are exposed in here, which gives more flexibility in certain scenarios, like certain casts that fire a bit after the cast bar finishes.

**DirectorFunctions** has a new `DirectorUnknownUpdate` method (called like that because it's not named in ClientStructs), which is needed for certain situations, like properly enabling Ultima's arena (just changing the weather leaves you floating in the void).

To allow for these changes, new native function classes were added: `ActorCastFunctions` and `ModelContainerFunctions`, alongside new helper methods in `MathUtil`