### PR TITLE
EventObjects Rework

### DIFF
--- a/AnoMech/Core/SimObjects/SimEventObject.cs
+++ b/AnoMech/Core/SimObjects/SimEventObject.cs
@@ -1,28 +1,79 @@
-using System.Numerics;
 using AnoMech.Core.Game;
-using AnoMech.Core.Native;
 using AnoMech.Helpers;
+using AnoMech.Pointers;
+using FFXIVClientStructs.FFXIV.Client.Game.Event;
+using FFXIVClientStructs.FFXIV.Client.Game.Network;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using System.Numerics;
 
 namespace AnoMech.Core.SimObjects;
 
-// Placement.Position is scenario-local (offset from SimWorld.ScenarioOrigin) —
-// same coordinate space as SimEventObject.Position / SetPosition once spawned.
-// EObjRowId references Lumina's EObj sheet — the row's SgbPath/PopType drives
-// the model picked by the engine's internal SharedGroup attach. ModelChara
-// substitution is not part of the EObj pipeline; pick the right EObj row.
-//
-// VisibleState is the SG state index that means "visible" for this EObj. The
-// orb (1EB83C) is already visible at the engine default state=0, so leave it
-// at 0. The Sigma ground circles (1EB83D / 1EB83E) need state=16 to render
-// fully; state=1..6 partial-renders are the engine's player-proximity animation
-// frames. SetVisible toggles between this value and 0.
-public record struct EventObjectSpawnConfig(
-    uint EObjRowId,
-    Placement Placement = default,
-    bool IsVisible = true,
-    short VisibleState = 0,
-    float Lifetime = 0f);
+public class EventObjectSpawnConfig
+{
+    // References Lumina's EObj sheet,
+    // the row's SgbPath/PopType drives the model picked by the engine's internal SharedGroup attach.
+    // ModelChara substitution is not part of the EObj pipeline; pick the right EObj row.
+    public uint EObjId { get; init; }
+
+    // Placement.Position is scenario-local (offset from SimWorld.ScenarioOrigin),
+    // same coordinate space as SimEventObject.Position / SetPosition once spawned.
+    public Placement Placement { get; init; }
+
+    public sbyte ObjectIndex { get; init; } = -1;
+    public byte TargetableStatus { get; init; } = 0;
+    public byte VisibilityFlag { get; init; } = 0;
+    public uint EntityId { get; init; } = 0;
+    public uint LayoutId { get; init; } = 0;
+    public EventId EventId { get; init; } = 0;
+    public uint OwnerId { get; init; } = 0xE0000000;
+    public uint GimmickId { get; init; } = 0;
+    public float Radius { get; init; } = 1;
+    public ushort FateId { get; init; } = 0;
+    public byte EventState { get; init; } = 0;
+
+    // This is the SG state index that means "visible" for this EObj.
+    // The orb (1EB83C) is already visible at the engine default state=0, so leave it at 0.
+    // The Sigma ground circles (1EB83D / 1EB83E) need state=16 to render fully
+    // state=1..6 partial-renders are the engine's player-proximity animation frames. SetVisible toggles between this value and 0.
+    public ushort TimelineState { get; init; } = 0;
+
+    public bool SpawnVisible { get; init; } = true;
+    public float Lifetime { get; init; } = 0;
+
+    public unsafe SpawnObjectPacket ToPacket(SimWorld world)
+    {
+        var objectIndex = sbyte.Max(-1, ObjectIndex);
+        var worldPos = world.Coordinates.ToGlobal(Placement.Position);
+
+        var packet = new SpawnObjectPacket
+        {
+            ObjectIndex = (byte)objectIndex,
+            ObjectKind = 7, // EventObject
+            TargetableStatus = TargetableStatus,
+            Visibility = VisibilityFlag,
+            BaseId = EObjId,
+            EntityId = EntityId,
+            LayoutId = LayoutId,
+            EventId = EventId,
+            OwnerId = OwnerId,
+            GimmickId = GimmickId,
+            Radius = Radius,
+            Rotation = MathUtil.QuantizeRotation(Placement.Rotation),
+            FateId = FateId,
+            EventState = EventState,
+            PositionX = worldPos.X,
+            PositionY = worldPos.Y,
+            PositionZ = worldPos.Z
+        };
+
+        // private in CS, so we have to set it manually
+        var packetBytePtr = (byte*)&packet;
+        var timelineStatePtr = (ushort*)(packetBytePtr + 0x2C);
+        *timelineStatePtr = TimelineState;
+
+        return packet;
+    }
+}
 
 // Handle around an EventObject GameObject allocated via the manager's
 // CreateEventObject (the 40-slot pool exposed in GameObjectManager indices
@@ -44,7 +95,8 @@ public unsafe class SimEventObject : ISimObject, IPositioned
     private int slot = -1;
     private GameObject* obj;
     private readonly SimWorld world;
-    private readonly short visibleState;
+    private readonly ushort visibleState;
+    private readonly float lifetime;
 
     public uint EObjRowId { get; }
     public string DisplayName => $"EObj 0x{EObjRowId:X}";
@@ -60,36 +112,36 @@ public unsafe class SimEventObject : ISimObject, IPositioned
     public Vector3 Position { get; private set; }
     public float Rotation { get; private set; }
 
-    protected SimEventObject(int slot, GameObject* obj, SimWorld world, uint eObjRowId, short visibleState)
+    private float lifetimeElapsed { get; set; } = 0;
+
+    protected SimEventObject(int slot, GameObject* obj, SimWorld world, uint eObjRowId, ushort visibleState, float lifetime)
     {
         this.slot = slot;
         this.obj = obj;
         this.world = world;
         this.visibleState = visibleState;
+        this.lifetime = lifetime;
         EObjRowId = eObjRowId;
     }
 
     internal static SimEventObject? Spawn(EventObjectSpawnConfig config, SimWorld world, EventScheduler events)
     {
-        if (!EventObjectHelper.Create(config.EObjRowId, out var slot, out var obj))
+        var packet = config.ToPacket(world);
+
+        if (!EventObjectHelper.Create(&packet, out var slot, out var eObjPtr))
+        {
             return null;
+        }
 
-        var worldPos = world.Coordinates.ToGlobal(config.Placement.Position);
-        obj->SetPosition(worldPos.X, worldPos.Y, worldPos.Z);
-        obj->SetRotation(MathUtil.NormalizeRotation(config.Placement.Rotation));
+        var eObj = new SimEventObject(slot, eObjPtr, world, config.EObjId, config.TimelineState, config.Lifetime);
 
-        var eo = new SimEventObject(slot, obj, world, config.EObjRowId, config.VisibleState);
-        // Seed stored Position/Rotation. The native struct writes above are
-        // authoritative for the engine; SetPosition mirrors them into the C#
-        // fields (and harmlessly re-pushes to native).
-        eo.SetPosition(config.Placement);
-        if (config.IsVisible && config.VisibleState != 0)
-            eo.SetState(config.VisibleState);
+        if (!config.SpawnVisible && config.TimelineState != 0)
+        {
+            eObj.SetVisible(false);
+        }
 
-        if (config.Lifetime > 0f) events.Add(config.Lifetime, eo.Despawn);
-
-        Plugin.Log.Info($"SimEventObject: spawned EObj 0x{config.EObjRowId:X} at slot {slot} ({worldPos.X:F2},{worldPos.Y:F2},{worldPos.Z:F2})");
-        return eo;
+        Plugin.Log.Info($"[SimEventObject.Create] Spawned EObj with EObjId 0x{config.EObjId:X} at Slot: {slot} ({packet.PositionX:F2}, {packet.PositionY:F2}, {packet.PositionZ:F2})");
+        return eObj;
     }
 
     public void SetPosition(Vector3 position)
@@ -116,7 +168,7 @@ public unsafe class SimEventObject : ISimObject, IPositioned
     // experiment empirically to find what activates a given visual. Safe to
     // call before the SG instance is attached: only the field write happens,
     // the notify silently no-ops; the engine picks up the field once attached.
-    public void SetState(short state)
+    public void SetState(ushort state)
     {
         if (obj == null) return;
         EventObjectHelper.SetState(obj, state);
@@ -125,7 +177,7 @@ public unsafe class SimEventObject : ISimObject, IPositioned
     // Convenience for parser-driven scenarios that emit SetVisible from
     // ACT 261|Change ModelStatus events. Flips between the configured
     // VisibleState and 0 (the engine default / "hidden" for gated SGs).
-    public void SetVisible(bool visible) => SetState(visible ? visibleState : (short)0);
+    public void SetVisible(bool visible) => SetState(visible ? visibleState : (ushort)0);
 
     public virtual void Tick(float deltaSeconds)
     {
@@ -133,18 +185,40 @@ public unsafe class SimEventObject : ISimObject, IPositioned
         // direct-struct writes between Ticks (engine doesn't move EObjs on
         // its own, but the parallel pattern with SimNpc keeps the contract
         // uniform across IPositioned implementers).
-        if (obj == null) return;
+        if (obj == null)
+        {
+            return;
+        }
+
         Position = world.Coordinates.ToLocal(obj->Position);
         Rotation = obj->Rotation;
+
+        if (lifetime > 0)
+        {
+            lifetimeElapsed += deltaSeconds;
+
+            if (lifetimeElapsed >= lifetime)
+            {
+                Despawn();
+            }
+        }
     }
 
     public void Despawn()
     {
         if (slot < 0) return;
         var releasedSlot = slot;
+
         slot = -1;
         obj = null;
-        EventObjectHelper.Destroy(releasedSlot);
+
+        byte[] packet = [(byte)releasedSlot];
+
+        fixed (byte* packetPtr = packet)
+        {
+            PacketDispatcherPointers.HandleDespawnObjectPacket(0, packetPtr);
+        }
+
         Plugin.Log.Info($"SimEventObject: despawned slot {releasedSlot}");
     }
 }

--- a/AnoMech/Core/SimObjects/SimTower.cs
+++ b/AnoMech/Core/SimObjects/SimTower.cs
@@ -1,5 +1,4 @@
 using AnoMech.Core.Game;
-using AnoMech.Core.Native;
 using AnoMech.Helpers;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 
@@ -15,12 +14,12 @@ public sealed unsafe class SimTower : SimEventObject
 {
     private readonly SimParty party;
     private readonly float radius;
-    private readonly short[] states;
+    private readonly ushort[] states;
     private int? lastCount;
 
     private SimTower(int slot, GameObject* obj, SimWorld world, uint eObjRowId,
-                     short[] states, float radius, SimParty party)
-        : base(slot, obj, world, eObjRowId, states[0])
+                     ushort[] states, float radius, SimParty party)
+        : base(slot, obj, world, eObjRowId, states[0], 0)
     {
         this.party = party;
         this.radius = radius;
@@ -29,7 +28,7 @@ public sealed unsafe class SimTower : SimEventObject
 
     internal static SimTower? Spawn(
         EventObjectSpawnConfig config, SimWorld world, EventScheduler events,
-        short[] states, float radius, SimParty party)
+        ushort[] states, float radius, SimParty party)
     {
         if (states == null || states.Length == 0)
         {
@@ -37,18 +36,20 @@ public sealed unsafe class SimTower : SimEventObject
             return null;
         }
 
-        if (!EventObjectHelper.Create(config.EObjRowId, out var slot, out var obj))
+        var packet = config.ToPacket(world);
+
+        if (!EventObjectHelper.Create(&packet, out var slot, out var obj))
             return null;
 
         var worldPos = world.Coordinates.ToGlobal(config.Placement.Position);
         obj->SetPosition(worldPos.X, worldPos.Y, worldPos.Z);
         obj->SetRotation(MathUtil.NormalizeRotation(config.Placement.Rotation));
 
-        var tower = new SimTower(slot, obj, world, config.EObjRowId, states, radius, party);
+        var tower = new SimTower(slot, obj, world, config.EObjId, states, radius, party);
 
         if (config.Lifetime > 0f) events.Add(config.Lifetime, tower.Despawn);
 
-        Plugin.Log.Info($"SimTower: spawned EObj 0x{config.EObjRowId:X} at slot {slot} ({worldPos.X:F2},{worldPos.Y:F2},{worldPos.Z:F2}) radius={radius:F1} states=[{string.Join(",", states)}]");
+        Plugin.Log.Info($"SimTower: spawned EObj 0x{config.EObjId:X} at slot {slot} ({worldPos.X:F2},{worldPos.Y:F2},{worldPos.Z:F2}) radius={radius:F1} states=[{string.Join(",", states)}]");
         return tower;
     }
 

--- a/AnoMech/Core/SimObjects/SimTower.cs
+++ b/AnoMech/Core/SimObjects/SimTower.cs
@@ -18,8 +18,8 @@ public sealed unsafe class SimTower : SimEventObject
     private int? lastCount;
 
     private SimTower(int slot, GameObject* obj, SimWorld world, uint eObjRowId,
-                     ushort[] states, float radius, SimParty party)
-        : base(slot, obj, world, eObjRowId, states[0], 0)
+                     ushort[] states, float radius, SimParty party, float lifetime)
+        : base(slot, obj, world, eObjRowId, states[0], lifetime)
     {
         this.party = party;
         this.radius = radius;
@@ -45,9 +45,7 @@ public sealed unsafe class SimTower : SimEventObject
         obj->SetPosition(worldPos.X, worldPos.Y, worldPos.Z);
         obj->SetRotation(MathUtil.NormalizeRotation(config.Placement.Rotation));
 
-        var tower = new SimTower(slot, obj, world, config.EObjId, states, radius, party);
-
-        if (config.Lifetime > 0f) events.Add(config.Lifetime, tower.Despawn);
+        var tower = new SimTower(slot, obj, world, config.EObjId, states, radius, party, config.Lifetime);
 
         Plugin.Log.Info($"SimTower: spawned EObj 0x{config.EObjId:X} at slot {slot} ({worldPos.X:F2},{worldPos.Y:F2},{worldPos.Z:F2}) radius={radius:F1} states=[{string.Join(",", states)}]");
         return tower;

--- a/AnoMech/Core/SimObjects/SimWorld.cs
+++ b/AnoMech/Core/SimObjects/SimWorld.cs
@@ -126,7 +126,7 @@ public sealed class SimWorld : ISimObject, IDisposable
     // many party members stand within `radius` of the EObj (counts past the
     // array length clamp to the last entry). Bound to the current Party so AI
     // and scenario movement drive the visual.
-    public SimTower? SpawnTower(EventObjectSpawnConfig config, short[] states, float radius)
+    public SimTower? SpawnTower(EventObjectSpawnConfig config, ushort[] states, float radius)
     {
         var tower = SimTower.Spawn(config, this, Events, states, radius, Party);
         if (tower != null) children.Add(tower);

--- a/AnoMech/Helpers/EventObjectHelper.cs
+++ b/AnoMech/Helpers/EventObjectHelper.cs
@@ -1,99 +1,51 @@
 using AnoMech.Pointers;
+using FFXIVClientStructs.FFXIV.Client.Game.Network;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using FFXIVClientStructs.FFXIV.Client.Network;
 
 namespace AnoMech.Helpers;
 
 internal static unsafe class EventObjectHelper
 {
-    // Allocates a new EventObject slot bound to the given EObj sheet row.
-    // Returns the manager slot index (0..39) on success, -1 on failure. The
-    // engine sets up the SharedGroup model internally via FUN_14174dac0; the
-    // caller is responsible for SetPosition/SetRotation/SetVisible afterwards.
-    public static bool Create(uint eObjRowId, out int slot, out GameObject* obj)
+    public static bool Create(SpawnObjectPacket* packet, out int slot, out GameObject* eventObject)
     {
-        slot = -1;
-        obj = null;
+        var manager = EventObjectManager.Instance();
 
-        var eventObjectManager = EventObjectManager.Instance();
-
-        if (eventObjectManager == null)
+        // Since the Packet Handle method does not return the ID, we do a manual check beforehand, and test if that ID was created.
+        if (packet->ObjectIndex == 0xFF) // -1
         {
-            Plugin.Log.Warning("[EventObjectHelper.Create] EventObjectManager.Instance() was null");
-            return false;
+            var freeId = -1;
+
+            for (int i = 0; i < 40; i++)
+            {
+                if (manager->EventObjects[i] == null)
+                {
+                    freeId = i;
+                    break;
+                }
+            }
+
+            if (freeId == -1)
+            {
+                slot = -1;
+                eventObject = null;
+                return false;
+            }
+
+            packet->ObjectIndex = (byte)freeId;
         }
 
-        // All other params 0: we want the engine to auto-resolve the SharedGroup
-        // from EObj.SgbPath. Inside CreateEventObject, FUN_14174dac0 contains:
-        //
-        //   if (param_5 == 0 && (actor[0x9c] & 4) == 0) {
-        //       actor->ExportedSGRowPtr = ExdModule.GetExportedSGRow(eobjRow.SgbPath);
-        //   }
-        //
-        // param_5 = 0 ✓. The bit-2 check on actor[0x9c] depends on our final
-        // `flag` arg: CreateEventObject writes `actor[0x9c] |= flag << 2`. flag=1
-        // sets bit 2, which causes the engine to skip the auto-lookup (the packet
-        // path needs the layer-side resolution since the server passes an explicit
-        // param_5). For simulator-spawned EObjs we want the EObj-sheet lookup, so
-        // flag must be 0 — confirmed empirically by reading actor->ExportedSGRowPtr
-        // after spawn.
-        slot = EventObjectManagerPointers.CreateEventObject(eventObjectManager, 0, eObjRowId, 0, 0, 0, -1, 0);
-        if (slot < 0)
-        {
-            Plugin.Log.Warning($"EventObjectSpawn: CreateEventObject returned -1 for EObj row {eObjRowId} (0x{eObjRowId:X}) — pool full or invalid row");
-            return false;
-        }
-
-        // CreateEventObject writes the new actor pointer into _EventObjects[slot]
-        // itself (matches the `param_1[slot + 2] = puVar3` line in the decompile).
-        // No GetObjectByIndex binding needed — index straight in.
-        obj = eventObjectManager->EventObjects[slot].Value;
-        if (obj == null)
-        {
-            Plugin.Log.Warning($"EventObjectSpawn: slot {slot} resolved but EventObjects[{slot}] is null");
-            return false;
-        }
-
-        return true;
-    }
-
-    // Per-slot teardown. CreateEventObject itself fires the vfunc at vtable+0x1E0
-    // when reusing an occupied slot — that's GameObject.Terminate (VirtualFunction(60))
-    // as bound by ClientStructs. We invoke the same canonical path, then null the
-    // manager's _EventObjects[slot] pointer to release the slot for reuse.
-    public static void Destroy(int slot)
-    {
-        if (slot < 0 || slot >= 40)
-        {
-            Plugin.Log.Warning($"[EventObjectHelper.Destroy] Invalid Slot ({slot}) was introduced.");
-            return;
-        }
-
-        var mgr = EventObjectManager.Instance();
-
-        if (mgr == null)
-        {
-            Plugin.Log.Warning("[EventObjectHelper.Destroy] EventObjectManager.Instance() was null.");
-            return;
-        }
-
-        var arr = mgr->EventObjects;
-        var entry = arr[slot].Value;
-
-        if (entry == null)
-        {
-            Plugin.Log.Warning("[EventObjectHelper.Destroy] entry was null.");
-            return;
-        }
-
-        entry->Terminate();
-        arr[slot] = (GameObject*)null;
+        PacketDispatcher.HandleSpawnObjectPacket(0, packet);
+        slot = packet->ObjectIndex;
+        eventObject = EventObjectManagerPointers.GetEventObjectByIndex(manager, (uint)slot);
+        return eventObject != null;
     }
 
     // Writes the EObj state field (actor[0x1B2]) and notifies the attached
     // SharedGroupLayoutInstance to switch sub-instances. Different SGs use
     // different state values to gate which sub-instances are visible —
     // simulator code finds the right value empirically per EObj row.
-    public static void SetState(GameObject* obj, short state)
+    public static void SetState(GameObject* obj, ushort state)
     {
         if (obj == null)
         {

--- a/AnoMech/Pointers/EventObjectManagerPointers.cs
+++ b/AnoMech/Pointers/EventObjectManagerPointers.cs
@@ -8,7 +8,11 @@ internal unsafe class EventObjectManagerPointers
     [Signature("48 89 5C 24 ?? 48 89 6C 24 ?? 57 41 54 41 57 48 83 EC ?? 8B", UseFlags = SignatureUseFlags.Pointer, ScanType = ScanType.Text)]
     public static CreateEventObjectDelegate CreateEventObject { get; private set; } = null!;
 
+    [Signature("83 FA 27 77", UseFlags = SignatureUseFlags.Pointer, ScanType = ScanType.Text)]
+    public static GetEventObjectByIndexDelegate GetEventObjectByIndex { get; private set; } = null!;
+
     public delegate int CreateEventObjectDelegate(EventObjectManager* thisPtr, uint entityId, uint eObjId, ulong a4, uint layoutId, uint gimmickId, int objectIndex, byte flag);
+    public delegate GameObject* GetEventObjectByIndexDelegate(EventObjectManager* eventObjectManager, uint index);
 
     public static void Initialize()
     {

--- a/AnoMech/Pointers/EventObjectPointers.cs
+++ b/AnoMech/Pointers/EventObjectPointers.cs
@@ -16,7 +16,7 @@ internal unsafe class EventObjectPointers
     // only writes the state field and skips the notify — engine populates
     // actor[0x108] asynchronously after the SG resource loads, so a later
     // call will propagate.
-    public delegate void SetEventObjectStateDelegate(EventObject* thisPtr, short state, byte immediate, ulong extra);
+    public delegate void SetEventObjectStateDelegate(EventObject* thisPtr, ushort state, byte immediate, ulong extra);
 
     public static void Initialize()
     {

--- a/AnoMech/Pointers/PacketDispatcherPointers.cs
+++ b/AnoMech/Pointers/PacketDispatcherPointers.cs
@@ -25,7 +25,11 @@ internal unsafe class PacketDispatcherPointers
     [Signature("40 53 57 48 81 EC ?? ?? ?? ?? 48 8B FA 8B", UseFlags = SignatureUseFlags.Pointer, ScanType = ScanType.Text)]
     public static HandleActorCastPacketDelegate HandleActorCastPacket { get; private set; } = null!;
 
+    [Signature("40 53 48 83 EC 20 48 8B DA 48 8D 0D ?? ?? ?? ?? 0F", UseFlags = SignatureUseFlags.Pointer, ScanType = ScanType.Text)]
+    public static HandleDespawnObjectPacketDelegate HandleDespawnObjectPacket { get; private set; } = null!;
+
     public delegate void HandleActorCastPacketDelegate(uint entityId, ActorCastPacket* packet);
+    public delegate void HandleDespawnObjectPacketDelegate(uint unused, byte* packet);
 
     public static void Initialize()
     {

--- a/AnoMech/Scenarios/Top/P5Sigma/TopP5SigmaScenario.cs
+++ b/AnoMech/Scenarios/Top/P5Sigma/TopP5SigmaScenario.cs
@@ -308,7 +308,7 @@ public sealed class TopP5SigmaScenario : IScenario
             var tower = state.Towers[i];
             if (tower == null) continue;
             SimEventObject? eventObj_1EB83C_4000A6E7 = null;
-            world.Events.Add(33.96f, () => eventObj_1EB83C_4000A6E7 = world.SpawnEventObject(new EventObjectSpawnConfig(EObjRowId: EObjId.TowerTimer, Placement: new Placement(tower.Position, -0.000f), IsVisible: false)));
+            world.Events.Add(33.96f, () => eventObj_1EB83C_4000A6E7 = world.SpawnEventObject(new EventObjectSpawnConfig { EObjId = EObjId.TowerTimer, Placement = new Placement(tower.Position, -0.000f), SpawnVisible = false }));
             world.Events.Add(34.02f, () => eventObj_1EB83C_4000A6E7?.SetVisible(true));
             world.Events.Add(43.66f, () => eventObj_1EB83C_4000A6E7?.Despawn());
         }
@@ -322,9 +322,9 @@ public sealed class TopP5SigmaScenario : IScenario
             var tower = state.Towers[i];
             if (tower == null) continue;
             var eObjId = tower.MinPlayers == 1 ? EObjId.TowerSolo : EObjId.TowerPair;
-            short[] stateIds = tower.MinPlayers == 1 ? [1, 16] : [1, 16, 32];
+            ushort[] stateIds = tower.MinPlayers == 1 ? [1, 16] : [1, 16, 32];
             SimEventObject? eventObj_1EB83E_4000A6E8 = null;
-            world.Events.Add(33.96f, () => eventObj_1EB83E_4000A6E8 = world.SpawnTower(new EventObjectSpawnConfig(EObjRowId: eObjId, Placement: new Placement(tower.Position, -0.000f), IsVisible: false), stateIds, Geometry.TowerRadius));
+            world.Events.Add(33.96f, () => eventObj_1EB83E_4000A6E8 = world.SpawnTower(new EventObjectSpawnConfig { EObjId = eObjId, Placement = new Placement(tower.Position, -0.000f), SpawnVisible = false }, stateIds, Geometry.TowerRadius));
             world.Events.Add(34.02f, () => eventObj_1EB83E_4000A6E8?.SetVisible(true));
             world.Events.Add(43.66f, () => eventObj_1EB83E_4000A6E8?.Despawn());
         }

--- a/AnoMech/Windows/DebugMenu.cs
+++ b/AnoMech/Windows/DebugMenu.cs
@@ -131,9 +131,11 @@ internal sealed unsafe class DebugMenu
                 // this in Game.RunScenarioInternal.
                 var player = Plugin.ObjectTable.LocalPlayer;
                 if (player != null) plugin.Game.World.ScenarioOrigin = player.Position;
-                plugin.Game.World.SpawnEventObject(new EventObjectSpawnConfig(
-                    EObjRowId: eObjRowId,
-                    IsVisible: true));
+                plugin.Game.World.SpawnEventObject(new EventObjectSpawnConfig
+                {
+                    EObjId = eObjRowId,
+                    SpawnVisible = true
+                });
             }
         }
 
@@ -583,7 +585,7 @@ internal sealed unsafe class DebugMenu
     // N increments each click. SGs gate sub-instance visibility on this state
     // field — we use this to find empirically which value activates a given
     // EObj's hidden visuals (e.g., the P5 Sigma tower ground circles).
-    private static short eventObjectStateProbe;
+    private static ushort eventObjectStateProbe;
     private void BumpEventObjectState()
     {
         eventObjectStateProbe++;


### PR DESCRIPTION
Contrary to what `SimEventObject` warns, using `HandleSpawnObjectPacket` is not that complex, if provided a valid packet. To help achieve this, these changes have been made:

- The following Pointers were added to be able to make the following changes: `EventObjectManagerPointers.GetEventObjectByIndex` and `PacketDispatcherPointers.HandleDespawnObjectPacket`.
- `EventObjectHelper.Create` now uses `PacketDispatcher.HandleSpawnObjectPacket`, and does some manual verifications to ensure the `EventObject` was created properly. This means the caller is no longer resposible for calling `SetPosition/SetRotation/SetVisible` afterwards.
- `EventObjectSpawnConfig` has been expanded to support all parameters sent in `SpawnObjectPacket`, except all non-EventObject parameters, of course (for which, to be safe, the `ObjectKind` is hardcoded to 7). An example of something needing this is UWU's Death Wall, which requires the `GimmickId` to be sent, or else it won't display properly.
- `EObjRowId` name was simplified to `EObjId`, and the comment is kept in case the user needs some clarification.
- `IsVisible` was renamed to `SpawnVisible`.
- `VisibleState` was renamed to `TimelineState` in the Config, and the type was changed from `short` to `ushort`, since it doesn't reflect a real numeric value and is instead used as a bitmask.
- `Lifetime` now works by keeping track of the elapsed time since the `SimEventObject` was created in `Tick`, and once the `Lifetime` value has been reached, `SimEventObject.Despawn` is called.
- `EventObjectHelper.Destroy` was deleted in favor to use `PacketDispatcherPointers.HandleDespawnObjectPacket`.

These changes are fully compatible with how `SimEventObject` worked before, so it does not break the already existing Scenarios.
The `Lifetime` property in the Config was not used previously, so effectively the only changes made to existing Scenarios was the rename of the other properties already mentioned.