### PR TITLE
Duty Information and (Item) Level Sync

### DIFF
--- a/AnoMech/Core/Game/Game.cs
+++ b/AnoMech/Core/Game/Game.cs
@@ -100,7 +100,7 @@ public sealed class Game : IDisposable
         var freshLoad = !World.Map.IsZoneLoaded;
 
         World.HideObject(ExitObjectBaseId);
-        World.Map.TryLoad(scenario.TargetInstance);
+        World.Map.TryLoad(scenario.TargetInstance, scenario.Level, scenario.ItemLevel);
         World.ScenarioOrigin = scenario.TargetInstance.Origin;
         World.Map.ArmColliderDrops(scenario.ColliderRemovalPoints.Select(World.Coordinates.ToGlobal));
         World.PlaceWaymarks(scenario.Waymarks);

--- a/AnoMech/Core/Map/MapController.cs
+++ b/AnoMech/Core/Map/MapController.cs
@@ -39,7 +39,7 @@ public sealed class MapController : IDisposable
     public bool IsInInn() => ZoneSession.IsInInn();
 
     // Load the target territory client-side. Must be called from the Inn.
-    public void Load(uint territoryId, Vector3 playerPosition) => zone.Enter(territoryId, playerPosition);
+    public void Load(uint territoryId, Vector3 playerPosition, byte levelSync, ushort itemLevelSync) => zone.Enter(territoryId, playerPosition, levelSync, itemLevelSync);
 
     // Apply weather after a zone load (1-second delayed to let the engine settle).
     public void ApplyWeather(byte weatherId) => zone.ApplyWeather(weatherId);
@@ -79,7 +79,7 @@ public sealed class MapController : IDisposable
     // Enter the scenario's target instance if conditions are met.
     // Sets IsInInstance when the zone is already active or the Inn load succeeds.
     // No-op (IsInInstance stays false) when target is null or the player isn't in the Inn.
-    public void TryLoad(TargetInstance? target)
+    public void TryLoad(TargetInstance? target, byte levelSync, ushort itemLevelSync)
     {
         if (target == null) return;
         // Fresh load only when no zone is active yet (must be in the Inn). When a
@@ -89,7 +89,7 @@ public sealed class MapController : IDisposable
         if (!IsZoneLoaded)
         {
             if (!IsInInn()) return;
-            Load(target.TerritoryId, target.PlayerPosition);
+            Load(target.TerritoryId, target.PlayerPosition, levelSync, itemLevelSync);
             freshLoad = true;
         }
         if (target.WeatherId is { } wid)

--- a/AnoMech/Core/Map/ZoneSession.cs
+++ b/AnoMech/Core/Map/ZoneSession.cs
@@ -542,46 +542,18 @@ public sealed unsafe class ZoneSession : IDisposable
                 // Add extra stats
                 ApplyExtraStats(stats, GetMateriaStats(inventoryItem));
                 ApplyExtraStats(stats, GetMandervilleWeaponStats(inventoryItem));
-
-                foreach(var (attribute, value) in GetMateriaStats(inventoryItem))
-                {
-                    if (!stats.ContainsKey(attribute))
-                    {
-                        continue;
-                    }
-
-                    stats[attribute] += value;
-                }
-
-                foreach (var (attribute, value) in GetMandervilleWeaponStats(inventoryItem))
-                {
-                    if (!stats.ContainsKey(attribute))
-                    {
-                        continue;
-                    }
-
-                    stats[attribute] += value;
-                }
             }
             else // Calculate the sync value
             {
-                if (inventoryItem.Slot == 0 || inventoryItem.Slot == 1)
-                {
-                    // Determine if Resistance weapon
-                    var resistanceSheet = Plugin.DataManager.GetExcelSheet<ResistanceWeaponAdjust>();
-                    if (resistanceSheet.TryGetRow(itemId, out var _))
-                    {
-                        ApplyExtraStats(stats, GetMateriaStats(inventoryItem));
-                    }
+                var resistanceStats = new Dictionary<int, int>();
 
-                    // Determine if Manderville weapon
-                    var mandervilleSheet = Plugin.DataManager.GetExcelSheet<MandervilleWeaponEnhance>();
-                    if (mandervilleSheet.TryGetRow(itemId, out var _))
-                    {
-                        ApplyExtraStats(stats, GetMateriaStats(inventoryItem));
-                        ApplyExtraStats(stats, GetMandervilleWeaponStats(inventoryItem));
-                    }
+                var resistanceSheet = Plugin.DataManager.GetExcelSheet<ResistanceWeaponAdjust>();
+                if (resistanceSheet.TryGetRow(itemId, out var _))
+                {
+                    resistanceStats = GetMateriaStats(inventoryItem);
                 }
+
+                var mandervilleStats = GetMandervilleWeaponStats(inventoryItem);
 
                 // Doing this instead of calling ExdModule.GetItemRowById because it's not guaranteed to always return on this frame
                 var dummyItem = new byte[0xA0];
@@ -601,8 +573,20 @@ public sealed unsafe class ZoneSession : IDisposable
                             continue;
                         }
 
-                        var paramMaxValue = (int)InventoryItem.GetParameterMaxValue((uint)baseParamId, dummyItemPtr);
-                        var syncedValue = int.Min(item.BaseParamValue[x], paramMaxValue);
+                        var statValue = item.BaseParamValue[x];
+
+                        if (resistanceStats.TryGetValue(baseParamId, out var resistanceStat))
+                        {
+                            statValue += (short)resistanceStat;
+                        }
+
+                        if (mandervilleStats.TryGetValue(baseParamId, out var mandervilleStat))
+                        {
+                            statValue += (short)mandervilleStat;
+                        }
+
+                        var statMaxValue = (int)InventoryItem.GetParameterMaxValue((uint)baseParamId, dummyItemPtr);
+                        var syncedValue = int.Min(statValue, statMaxValue);
                         stats[baseParamId] += syncedValue;
 
                         Plugin.Log.Debug($"Item \"{item.Name}\" (ilvl {item.LevelItem.RowId})'s {(PlayerAttribute)baseParamId} was synced to {syncedValue}");

--- a/AnoMech/Core/Map/ZoneSession.cs
+++ b/AnoMech/Core/Map/ZoneSession.cs
@@ -35,7 +35,9 @@ public sealed unsafe class ZoneSession : IDisposable
         public float Rotation { get; set; }
         public int Exp { get; set; }
         public uint RestedExp { get; set; }
+        public bool LevelSync { get; set; }
         public int Level { get; set; }
+        public bool ItemLevelSync { get; set; }
         public Dictionary<int, int> Attributes { get; } = new();
     }
 
@@ -137,7 +139,7 @@ public sealed unsafe class ZoneSession : IDisposable
 
     // Load the target territory, teleport player to playerSpawn, enable firewall.
     // Firewall is enabled before the zone load (matching Hyperborea's sequence).
-    public void Enter(uint territoryId, Vector3 playerSpawn)
+    public void Enter(uint territoryId, Vector3 playerSpawn, byte levelSync, ushort itemLevelSync)
     {
         var localPlayer = Plugin.ObjectTable.LocalPlayer!;
 
@@ -146,7 +148,9 @@ public sealed unsafe class ZoneSession : IDisposable
         sessionSave.Rotation = localPlayer.Rotation;
         sessionSave.Exp = Plugin.PlayerState.GetClassJobExperience(Plugin.PlayerState.ClassJob.Value);
         sessionSave.RestedExp = Plugin.PlayerState.BaseRestedExperience;
+        sessionSave.LevelSync = levelSync != 0;
         sessionSave.Level = localPlayer.Level;
+        sessionSave.ItemLevelSync = itemLevelSync != 0;
         sessionSave.Attributes.Clear();
 
         EnableFirewall();
@@ -394,45 +398,51 @@ public sealed unsafe class ZoneSession : IDisposable
     // (Item) Level Sync
     private void SetSync(ContentFinderCondition cfc, Character* player, uint territory, byte classJobId)
     {
-        var currentLevel = (byte)Plugin.PlayerState.Level;
-
         var cfcLevelSync = cfc.ClassJobLevelSync;
-        var levelSynced = currentLevel > cfcLevelSync;
 
-        if (levelSynced)
+        if (sessionSave.LevelSync)
         {
-            if (player != null)
+            var currentLevel = (byte)Plugin.PlayerState.Level;
+            var levelSynced = currentLevel > cfcLevelSync;
+
+            if (levelSynced)
             {
-                player->Level = cfcLevelSync;
+                if (player != null)
+                {
+                    player->Level = cfcLevelSync;
+                }
+
+                var updateClassInfoPacket = new UpdateClassInfoPacket
+                {
+                    ClassJobId = classJobId,
+                    CurrentLevel = currentLevel,
+                    ClassJobLevel = currentLevel,
+                    SyncedLevel = cfcLevelSync,
+                    ClassJobExp = 0,
+                    BaseRestedExperience = 0
+                };
+
+                PacketDispatcherPointers.HandleUpdateClassInfoPacket(0, &updateClassInfoPacket);
             }
-
-            var updateClassInfoPacket = new UpdateClassInfoPacket
-            {
-                ClassJobId = classJobId,
-                CurrentLevel = currentLevel,
-                ClassJobLevel = currentLevel,
-                SyncedLevel = cfcLevelSync,
-                ClassJobExp = 0,
-                BaseRestedExperience = 0
-            };
-
-            PacketDispatcherPointers.HandleUpdateClassInfoPacket(0, &updateClassInfoPacket);
         }
 
-        var uiState = UIState.Instance();
-        if (uiState != null)
+        if (sessionSave.ItemLevelSync)
         {
-            var ilvlSync = cfc.ItemLevelSync != 0 ? cfc.ItemLevelSync : cfc.ItemLevelRequired;
-
-            if (ilvlSync != 0)
+            var uiState = UIState.Instance();
+            if (uiState != null)
             {
-                Plugin.Log.Debug($"Setting up iLvl sync to {ilvlSync}");
-                var syncedAttributes = GetSyncedAttributes(cfcLevelSync, ilvlSync);
+                var ilvlSync = cfc.ItemLevelSync != 0 ? cfc.ItemLevelSync : cfc.ItemLevelRequired;
 
-                foreach (var (baseParamId, value) in syncedAttributes)
+                if (ilvlSync != 0)
                 {
-                    sessionSave.Attributes[baseParamId] = uiState->PlayerState.Attributes[baseParamId];
-                    uiState->PlayerState.Attributes[baseParamId] = value;
+                    Plugin.Log.Debug($"Setting up iLvl sync to {ilvlSync}");
+                    var syncedAttributes = GetSyncedAttributes(cfcLevelSync, ilvlSync);
+
+                    foreach (var (baseParamId, value) in syncedAttributes)
+                    {
+                        sessionSave.Attributes[baseParamId] = uiState->PlayerState.Attributes[baseParamId];
+                        uiState->PlayerState.Attributes[baseParamId] = value;
+                    }
                 }
             }
         }
@@ -440,24 +450,27 @@ public sealed unsafe class ZoneSession : IDisposable
 
     private void ResetSync(UIState* uiState, Character* player, byte classJobId)
     {
-        var updateClassInfoPacket = new UpdateClassInfoPacket
+        if (sessionSave.LevelSync)
         {
-            ClassJobId = classJobId,
-            CurrentLevel = (ushort)sessionSave.Level,
-            ClassJobLevel = (ushort)sessionSave.Level,
-            SyncedLevel = 0,
-            ClassJobExp = (ushort)sessionSave.Exp,
-            BaseRestedExperience = sessionSave.RestedExp
-        };
+            var updateClassInfoPacket = new UpdateClassInfoPacket
+            {
+                ClassJobId = classJobId,
+                CurrentLevel = (ushort)sessionSave.Level,
+                ClassJobLevel = (ushort)sessionSave.Level,
+                SyncedLevel = 0,
+                ClassJobExp = (ushort)sessionSave.Exp,
+                BaseRestedExperience = sessionSave.RestedExp
+            };
 
-        PacketDispatcherPointers.HandleUpdateClassInfoPacket(0, &updateClassInfoPacket);
+            PacketDispatcherPointers.HandleUpdateClassInfoPacket(0, &updateClassInfoPacket);
 
-        if (player != null)
-        {
-            player->Level = (byte)sessionSave.Level;
+            if (player != null)
+            {
+                player->Level = (byte)sessionSave.Level;
+            }
         }
 
-        if (uiState != null)
+        if (sessionSave.ItemLevelSync && uiState != null)
         {
             foreach (var (baseParamId, value) in sessionSave.Attributes)
             {

--- a/AnoMech/Core/Map/ZoneSession.cs
+++ b/AnoMech/Core/Map/ZoneSession.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Linq;
-using System.Numerics;
-using System.Reflection;
-using System.Runtime.InteropServices;
+using AnoMech.Helpers;
 using AnoMech.Pointers;
 using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
@@ -11,10 +7,16 @@ using Dalamud.Hooking;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Event;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Client.Graphics.Environment;
 using FFXIVClientStructs.FFXIV.Client.Network;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using Lumina.Excel.Sheets;
+using System;
+using System.Linq;
+using System.Numerics;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using static FFXIVClientStructs.FFXIV.Client.Network.PacketDispatcher.Delegates;
 using ThreadingTask = System.Threading.Tasks.Task;
 
@@ -250,6 +252,13 @@ public sealed unsafe class ZoneSession : IDisposable
         Plugin.Log.Information("[ZoneSession] Step 1: FinalizeInstanceContent");
         if (loadedInstanceContent != null)
         {
+            var uiState = UIState.Instance();
+
+            if (uiState != null)
+            {
+                uiState->DirectorTodo.IsShown = false;
+            }
+
             EventFrameworkPointers.TerminateDirector(eventFramework, 0x80030000 + loadedInstanceContent.Value);
             loadedInstanceContent = null;
         }
@@ -262,15 +271,20 @@ public sealed unsafe class ZoneSession : IDisposable
         }
 
         Plugin.Log.Information("[ZoneSession] Step 3: InitDirector");
-        var content = GetContentId(territory);
-        Plugin.Log.Information($"[ZoneSession] ContentId={content}");
-        if (content is { } cid && cid != 0)
+
+        var cfc = GetContentFinderCondition(territory);
+
+        if (cfc != null)
         {
-            EventFrameworkPointers.InitDirector(eventFramework, 0x80030000 + cid, cid, 0);
+            var contentId = cfc.Value.Content.RowId;
+            Plugin.Log.Information($"[ZoneSession] ContentId={contentId}");
+
+            EventFrameworkPointers.InitDirector(eventFramework, 0x80030000 + contentId, contentId, 0);
 
             if (!unloading)
             {
-                loadedInstanceContent = cid;
+                loadedInstanceContent = contentId;
+                InstanceContentDirectorHelper.SetDutyData(cfc.Value);
             }
         }
 
@@ -303,11 +317,25 @@ public sealed unsafe class ZoneSession : IDisposable
         }
     }
 
-    private static uint? GetContentId(uint territoryId)
+    private ContentFinderCondition? GetContentFinderCondition(uint territoryId)
     {
-        var row = Plugin.DataManager.GetExcelSheet<TerritoryType>()?.GetRowOrDefault(territoryId);
-        var cid = row?.ContentFinderCondition.ValueNullable?.Content.RowId;
-        return cid is null or 0 ? null : cid;
+        var sheet = Plugin.DataManager.GetExcelSheet<TerritoryType>();
+
+        if (sheet == null)
+        {
+            Plugin.Log.Debug($"[ZoneSession.GetContentFinderCondition] TerritoryType sheet was null.");
+            return null;
+        }
+
+        var rowRef = sheet[territoryId].ContentFinderCondition;
+
+        if (!rowRef.IsValid)
+        {
+            Plugin.Log.Debug($"TerritoryType sheet, index {territoryId} does not have a valid ContentFinderCondition reference.");
+            return null;
+        }
+
+        return rowRef.Value;
     }
 
     private static void SyncClientStateTerritoryType(ushort territory)

--- a/AnoMech/Core/Map/ZoneSession.cs
+++ b/AnoMech/Core/Map/ZoneSession.cs
@@ -52,7 +52,9 @@ public sealed unsafe class ZoneSession : IDisposable
 
     private uint savedTerritoryId;
     private Vector3 savedPosition;
-    public float savedRotation;
+    private float savedRotation;
+    private int savedExp;
+    private uint savedRestedExp;
 
     // ── Construction ──────────────────────────────────────────────────────────
 
@@ -134,6 +136,8 @@ public sealed unsafe class ZoneSession : IDisposable
         savedTerritoryId = Plugin.ClientState.TerritoryType;
         savedPosition = localPlayer.Position;
         savedRotation = localPlayer.Rotation;
+        savedExp = Plugin.PlayerState.GetClassJobExperience(Plugin.PlayerState.ClassJob.Value);
+        savedRestedExp = Plugin.PlayerState.BaseRestedExperience;
 
         EnableFirewall();
         LoadZoneInternal(territoryId, false, playerSpawn);
@@ -249,6 +253,9 @@ public sealed unsafe class ZoneSession : IDisposable
             return;
         }
 
+        var classJobId = (byte)Plugin.PlayerState.ClassJob.RowId;
+        var currentLevel = (byte)Plugin.PlayerState.Level;
+
         Plugin.Log.Information("[ZoneSession] Step 1: FinalizeInstanceContent");
         if (loadedInstanceContent != null)
         {
@@ -261,6 +268,18 @@ public sealed unsafe class ZoneSession : IDisposable
 
             EventFrameworkPointers.TerminateDirector(eventFramework, 0x80030000 + loadedInstanceContent.Value);
             loadedInstanceContent = null;
+
+            var updateClassInfoPacket = new UpdateClassInfoPacket
+            {
+                ClassJobId = classJobId,
+                CurrentLevel = currentLevel,
+                ClassJobLevel = currentLevel,
+                SyncedLevel = 0,
+                ClassJobExp = (ushort)savedExp,
+                BaseRestedExperience = savedRestedExp
+            };
+
+            PacketDispatcherPointers.HandleUpdateClassInfoPacket(0, &updateClassInfoPacket);
         }
 
         Plugin.Log.Information("[ZoneSession] Step 2: DisableDraw all objects");
@@ -285,6 +304,21 @@ public sealed unsafe class ZoneSession : IDisposable
             {
                 loadedInstanceContent = contentId;
                 InstanceContentDirectorHelper.SetDutyData(cfc.Value);
+
+                var cfcLevelSync = cfc.Value.ClassJobLevelSync;
+                var shouldSync = currentLevel > cfcLevelSync;
+
+                var updateClassInfoPacket = new UpdateClassInfoPacket
+                {
+                    ClassJobId = classJobId,
+                    CurrentLevel = currentLevel,
+                    ClassJobLevel = currentLevel,
+                    SyncedLevel = shouldSync ? cfcLevelSync : (ushort)0,
+                    ClassJobExp = 0,
+                    BaseRestedExperience = 0
+                };
+
+                PacketDispatcherPointers.HandleUpdateClassInfoPacket(0, &updateClassInfoPacket);
             }
         }
 

--- a/AnoMech/Core/Map/ZoneSession.cs
+++ b/AnoMech/Core/Map/ZoneSession.cs
@@ -506,6 +506,7 @@ public sealed unsafe class ZoneSession : IDisposable
             }
         }
 
+        // Get Item Stats
         var inventoryManager = InventoryManager.Instance();
         var equippedItems = inventoryManager->GetInventoryContainer(InventoryType.EquippedItems);
 
@@ -591,6 +592,59 @@ public sealed unsafe class ZoneSession : IDisposable
 
                         Plugin.Log.Debug($"Item \"{item.Name}\" (ilvl {item.LevelItem.RowId})'s {(PlayerAttribute)baseParamId} was synced to {syncedValue}");
                     }
+                }
+            }
+        }
+
+        // Get Food Buffs
+        var localPlayer = (BattleChara*)Plugin.ObjectTable.LocalPlayer!.Address;
+
+        if (localPlayer != null)
+        {
+            var statusManager = localPlayer->StatusManager;
+
+            foreach (var status in statusManager.Status)
+            {
+                var statusId = status.StatusId;
+
+                if (statusId == 0 || statusId != 48)
+                {
+                    continue;
+                }
+                
+                var hq = status.Param > 10000;
+                var foodId = hq ? status.Param - 10000 : status.Param;
+
+                if (!Plugin.DataManager.GetExcelSheet<ItemFood>().TryGetRow((uint)foodId, out var food))
+                {
+                    continue;
+                }
+                
+                foreach (var bonus in food.Params)
+                {
+                    var stat = (int)bonus.BaseParam.RowId;
+                    
+                    if (stat == 0 || !stats.ContainsKey(stat))
+                    {
+                        continue;
+                    }
+
+                    var value = hq ? bonus.ValueHQ : bonus.Value;
+                    var max = hq ? bonus.MaxHQ : bonus.Max;
+                    int statBuff;
+
+                    if (bonus.IsRelative)
+                    {
+                        var currentStat = stats[stat];
+                        var percentBuff = (int)(currentStat * (value / 100f));
+                        statBuff = int.Min(percentBuff, max);
+                    }
+                    else
+                    {
+                        statBuff = value;
+                    }
+
+                    stats[stat] += statBuff;
                 }
             }
         }

--- a/AnoMech/Core/Map/ZoneSession.cs
+++ b/AnoMech/Core/Map/ZoneSession.cs
@@ -1,3 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using AnoMech.Helpers;
 using AnoMech.Pointers;
 using Dalamud.Game.Addon.Lifecycle;
@@ -12,11 +18,6 @@ using FFXIVClientStructs.FFXIV.Client.Graphics.Environment;
 using FFXIVClientStructs.FFXIV.Client.Network;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using Lumina.Excel.Sheets;
-using System;
-using System.Linq;
-using System.Numerics;
-using System.Reflection;
-using System.Runtime.InteropServices;
 using static FFXIVClientStructs.FFXIV.Client.Network.PacketDispatcher.Delegates;
 using ThreadingTask = System.Threading.Tasks.Task;
 
@@ -27,6 +28,17 @@ namespace AnoMech.Core.Map;
 // All public methods must be called from the framework thread.
 public sealed unsafe class ZoneSession : IDisposable
 {
+    private class SessionSave
+    {
+        public uint TerritoryId { get; set; }
+        public Vector3 Position { get; set; }
+        public float Rotation { get; set; }
+        public int Exp { get; set; }
+        public uint RestedExp { get; set; }
+        public int Level { get; set; }
+        public Dictionary<int, int> Attributes { get; } = new();
+    }
+
     // TerritoryIntendedUse.Inn = 2 (from ECommons TerritoryIntendedUseEnum)
     private const uint InnIntendedUse = 2;
 
@@ -50,11 +62,7 @@ public sealed unsafe class ZoneSession : IDisposable
 
     public bool IsActive { get; private set; }
 
-    private uint savedTerritoryId;
-    private Vector3 savedPosition;
-    private float savedRotation;
-    private int savedExp;
-    private uint savedRestedExp;
+    private readonly SessionSave sessionSave = new();
 
     // ── Construction ──────────────────────────────────────────────────────────
 
@@ -133,11 +141,13 @@ public sealed unsafe class ZoneSession : IDisposable
     {
         var localPlayer = Plugin.ObjectTable.LocalPlayer!;
 
-        savedTerritoryId = Plugin.ClientState.TerritoryType;
-        savedPosition = localPlayer.Position;
-        savedRotation = localPlayer.Rotation;
-        savedExp = Plugin.PlayerState.GetClassJobExperience(Plugin.PlayerState.ClassJob.Value);
-        savedRestedExp = Plugin.PlayerState.BaseRestedExperience;
+        sessionSave.TerritoryId = Plugin.ClientState.TerritoryType;
+        sessionSave.Position = localPlayer.Position;
+        sessionSave.Rotation = localPlayer.Rotation;
+        sessionSave.Exp = Plugin.PlayerState.GetClassJobExperience(Plugin.PlayerState.ClassJob.Value);
+        sessionSave.RestedExp = Plugin.PlayerState.BaseRestedExperience;
+        sessionSave.Level = localPlayer.Level;
+        sessionSave.Attributes.Clear();
 
         EnableFirewall();
         LoadZoneInternal(territoryId, false, playerSpawn);
@@ -166,9 +176,11 @@ public sealed unsafe class ZoneSession : IDisposable
         var condition = Conditions.Instance();
         condition->Occupied = true;
 
-        if (savedTerritoryId != 0)
-            LoadZoneInternal(savedTerritoryId, true, savedPosition, savedRotation);
-        savedTerritoryId = 0;
+        if (sessionSave.TerritoryId != 0)
+            LoadZoneInternal(sessionSave.TerritoryId, true, sessionSave.Position, sessionSave.Rotation);
+
+        sessionSave.TerritoryId = 0;
+
         IsActive = false;
         Plugin.Log.Information("[ZoneSession] Reverted to inn.");
 
@@ -179,7 +191,7 @@ public sealed unsafe class ZoneSession : IDisposable
             ThreadingTask.Delay(1000).ContinueWith(_ =>
             {
                 // The Player could do something like jump, so to be extremely sure we are where we are supposed to, we set the Position and Rotation again.
-                SetLocalPlayerPosition(savedPosition, savedRotation);
+                SetLocalPlayerPosition(sessionSave.Position, sessionSave.Rotation);
                 condition->Occupied = false;
 
                 DisableFirewall();
@@ -195,7 +207,7 @@ public sealed unsafe class ZoneSession : IDisposable
         else
         {
             // This skips all safety delays, so if possible, don't disable the plugin while being in a Scenario
-            SetLocalPlayerPosition(savedPosition, savedRotation);
+            SetLocalPlayerPosition(sessionSave.Position, sessionSave.Rotation);
             condition->Occupied = false;
             DisableFirewall();
             Plugin.Framework.Run(OpenSocialForPartyResync);
@@ -253,8 +265,13 @@ public sealed unsafe class ZoneSession : IDisposable
             return;
         }
 
+        var player = (Character*)Plugin.ObjectTable.LocalPlayer!.Address;
+        if (player == null)
+        {
+            Plugin.Log.Error("[ZoneSession] Plugin.ObjectTable.LocalPlayer was null.");
+        }
+
         var classJobId = (byte)Plugin.PlayerState.ClassJob.RowId;
-        var currentLevel = (byte)Plugin.PlayerState.Level;
 
         Plugin.Log.Information("[ZoneSession] Step 1: FinalizeInstanceContent");
         if (loadedInstanceContent != null)
@@ -269,17 +286,7 @@ public sealed unsafe class ZoneSession : IDisposable
             EventFrameworkPointers.TerminateDirector(eventFramework, 0x80030000 + loadedInstanceContent.Value);
             loadedInstanceContent = null;
 
-            var updateClassInfoPacket = new UpdateClassInfoPacket
-            {
-                ClassJobId = classJobId,
-                CurrentLevel = currentLevel,
-                ClassJobLevel = currentLevel,
-                SyncedLevel = 0,
-                ClassJobExp = (ushort)savedExp,
-                BaseRestedExperience = savedRestedExp
-            };
-
-            PacketDispatcherPointers.HandleUpdateClassInfoPacket(0, &updateClassInfoPacket);
+            ResetSync(uiState, player, classJobId);
         }
 
         Plugin.Log.Information("[ZoneSession] Step 2: DisableDraw all objects");
@@ -289,37 +296,25 @@ public sealed unsafe class ZoneSession : IDisposable
             ((FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)obj.Address)->DisableDraw();
         }
 
-        Plugin.Log.Information("[ZoneSession] Step 3: InitDirector");
-
-        var cfc = GetContentFinderCondition(territory);
-
-        if (cfc != null)
+        if (!unloading)
         {
-            var contentId = cfc.Value.Content.RowId;
+            Plugin.Log.Information("[ZoneSession] Step 3: InitDirector");
+
+            var cfc = GetContentFinderCondition(territory)!.Value;
+
+            var contentId = cfc.Content.RowId;
             Plugin.Log.Information($"[ZoneSession] ContentId={contentId}");
 
             EventFrameworkPointers.InitDirector(eventFramework, 0x80030000 + contentId, contentId, 0);
 
-            if (!unloading)
-            {
-                loadedInstanceContent = contentId;
-                InstanceContentDirectorHelper.SetDutyData(cfc.Value);
+            loadedInstanceContent = contentId;
+            InstanceContentDirectorHelper.SetDutyData(cfc);
 
-                var cfcLevelSync = cfc.Value.ClassJobLevelSync;
-                var shouldSync = currentLevel > cfcLevelSync;
-
-                var updateClassInfoPacket = new UpdateClassInfoPacket
-                {
-                    ClassJobId = classJobId,
-                    CurrentLevel = currentLevel,
-                    ClassJobLevel = currentLevel,
-                    SyncedLevel = shouldSync ? cfcLevelSync : (ushort)0,
-                    ClassJobExp = 0,
-                    BaseRestedExperience = 0
-                };
-
-                PacketDispatcherPointers.HandleUpdateClassInfoPacket(0, &updateClassInfoPacket);
-            }
+            SetSync(cfc, player, territory, classJobId);
+        }
+        else
+        {
+            Plugin.Log.Information("[ZoneSession] Step 3: InitDirector (Skipped)");
         }
 
         Plugin.Log.Information("[ZoneSession] Step 4: LoadZone (native)");
@@ -393,6 +388,307 @@ public sealed unsafe class ZoneSession : IDisposable
         catch (Exception e)
         {
             Plugin.Log.Warning($"[ZoneSession] Could not sync ClientState.TerritoryType: {e.Message}");
+        }
+    }
+
+    // (Item) Level Sync
+    private void SetSync(ContentFinderCondition cfc, Character* player, uint territory, byte classJobId)
+    {
+        var currentLevel = (byte)Plugin.PlayerState.Level;
+
+        var cfcLevelSync = cfc.ClassJobLevelSync;
+        var levelSynced = currentLevel > cfcLevelSync;
+
+        if (levelSynced)
+        {
+            if (player != null)
+            {
+                player->Level = cfcLevelSync;
+            }
+
+            var updateClassInfoPacket = new UpdateClassInfoPacket
+            {
+                ClassJobId = classJobId,
+                CurrentLevel = currentLevel,
+                ClassJobLevel = currentLevel,
+                SyncedLevel = cfcLevelSync,
+                ClassJobExp = 0,
+                BaseRestedExperience = 0
+            };
+
+            PacketDispatcherPointers.HandleUpdateClassInfoPacket(0, &updateClassInfoPacket);
+        }
+
+        var uiState = UIState.Instance();
+        if (uiState != null)
+        {
+            var ilvlSync = cfc.ItemLevelSync != 0 ? cfc.ItemLevelSync : cfc.ItemLevelRequired;
+
+            if (ilvlSync != 0)
+            {
+                Plugin.Log.Debug($"Setting up iLvl sync to {ilvlSync}");
+                var syncedAttributes = GetSyncedAttributes(cfcLevelSync, ilvlSync);
+
+                foreach (var (baseParamId, value) in syncedAttributes)
+                {
+                    sessionSave.Attributes[baseParamId] = uiState->PlayerState.Attributes[baseParamId];
+                    uiState->PlayerState.Attributes[baseParamId] = value;
+                }
+            }
+        }
+    }
+
+    private void ResetSync(UIState* uiState, Character* player, byte classJobId)
+    {
+        var updateClassInfoPacket = new UpdateClassInfoPacket
+        {
+            ClassJobId = classJobId,
+            CurrentLevel = (ushort)sessionSave.Level,
+            ClassJobLevel = (ushort)sessionSave.Level,
+            SyncedLevel = 0,
+            ClassJobExp = (ushort)sessionSave.Exp,
+            BaseRestedExperience = sessionSave.RestedExp
+        };
+
+        PacketDispatcherPointers.HandleUpdateClassInfoPacket(0, &updateClassInfoPacket);
+
+        if (player != null)
+        {
+            player->Level = (byte)sessionSave.Level;
+        }
+
+        if (uiState != null)
+        {
+            foreach (var (baseParamId, value) in sessionSave.Attributes)
+            {
+                uiState->PlayerState.Attributes[baseParamId] = value;
+            }
+        }
+    }
+
+    private Dictionary<int, int> GetSyncedAttributes(byte level, ushort ilvl)
+    {
+        var stats = new Dictionary<int, int>();
+
+        var itemSheet = Plugin.DataManager.GetExcelSheet<Item>();
+        var baseParamSheet = Plugin.DataManager.GetExcelSheet<BaseParam>();
+        var paramGrowSheet = Plugin.DataManager.GetExcelSheet<ParamGrow>();
+
+        var supportedAttributes = new PlayerAttribute[]
+        {
+                PlayerAttribute.SkillSpeed,
+                PlayerAttribute.SpellSpeed
+        };
+
+        foreach (var attribute in supportedAttributes)
+        {
+            switch (attribute)
+            {
+                case PlayerAttribute.SkillSpeed:
+                case PlayerAttribute.SpellSpeed:
+                    stats[(int)attribute] = paramGrowSheet[level].BaseSpeed;
+                    break;
+                default:
+                    continue;
+            }
+        }
+
+        var inventoryManager = InventoryManager.Instance();
+        var equippedItems = inventoryManager->GetInventoryContainer(InventoryType.EquippedItems);
+
+        for (int i = 0; i < equippedItems->GetSize(); i++)
+        {
+            var inventoryItem = equippedItems->Items[i];
+            var itemId = inventoryItem.ItemId;
+
+            if (itemId == 0)
+            {
+                continue;
+            }
+
+            var item = itemSheet[itemId];
+            var itemLevel = item.LevelItem.RowId;
+            
+            if (item.LevelItem.RowId <= ilvl) // Add it as is if the ilvl is the same or less than sync
+            {
+                Plugin.Log.Debug($"Item \"{item.Name}\" (ilvl {item.LevelItem.RowId}) fits the ilvl sync requirements.");
+
+                for (int x = 0; x < item.BaseParam.Count; x++)
+                {
+                    var baseParam = item.BaseParam[x];
+                    var baseParamId = (int)baseParam.RowId;
+
+                    if (!supportedAttributes.Contains((PlayerAttribute)baseParamId))
+                    {
+                        continue;
+                    }
+
+                    stats[baseParamId] += item.BaseParamValue[x];
+                }
+
+                // Add extra stats
+                ApplyExtraStats(stats, GetMateriaStats(inventoryItem));
+                ApplyExtraStats(stats, GetMandervilleWeaponStats(inventoryItem));
+
+                foreach(var (attribute, value) in GetMateriaStats(inventoryItem))
+                {
+                    if (!stats.ContainsKey(attribute))
+                    {
+                        continue;
+                    }
+
+                    stats[attribute] += value;
+                }
+
+                foreach (var (attribute, value) in GetMandervilleWeaponStats(inventoryItem))
+                {
+                    if (!stats.ContainsKey(attribute))
+                    {
+                        continue;
+                    }
+
+                    stats[attribute] += value;
+                }
+            }
+            else // Calculate the sync value
+            {
+                if (inventoryItem.Slot == 0 || inventoryItem.Slot == 1)
+                {
+                    // Determine if Resistance weapon
+                    var resistanceSheet = Plugin.DataManager.GetExcelSheet<ResistanceWeaponAdjust>();
+                    if (resistanceSheet.TryGetRow(itemId, out var _))
+                    {
+                        ApplyExtraStats(stats, GetMateriaStats(inventoryItem));
+                    }
+
+                    // Determine if Manderville weapon
+                    var mandervilleSheet = Plugin.DataManager.GetExcelSheet<MandervilleWeaponEnhance>();
+                    if (mandervilleSheet.TryGetRow(itemId, out var _))
+                    {
+                        ApplyExtraStats(stats, GetMateriaStats(inventoryItem));
+                        ApplyExtraStats(stats, GetMandervilleWeaponStats(inventoryItem));
+                    }
+                }
+
+                // Doing this instead of calling ExdModule.GetItemRowById because it's not guaranteed to always return on this frame
+                var dummyItem = new byte[0xA0];
+                fixed (byte* dummyItemPtr = dummyItem)
+                {
+                    *(dummyItemPtr + 0x54) = item.BaseParamModifier;
+                    *(ushort*)(dummyItemPtr + 0x8A) = ilvl;
+                    *(dummyItemPtr + 0x9A) = (byte)item.EquipSlotCategory.RowId;
+
+                    for (int x = 0; x < item.BaseParam.Count; x++)
+                    {
+                        var baseParam = item.BaseParam[x];
+                        var baseParamId = (int)baseParam.RowId;
+
+                        if (!supportedAttributes.Contains((PlayerAttribute)baseParamId))
+                        {
+                            continue;
+                        }
+
+                        var paramMaxValue = (int)InventoryItem.GetParameterMaxValue((uint)baseParamId, dummyItemPtr);
+                        var syncedValue = int.Min(item.BaseParamValue[x], paramMaxValue);
+                        stats[baseParamId] += syncedValue;
+
+                        Plugin.Log.Debug($"Item \"{item.Name}\" (ilvl {item.LevelItem.RowId})'s {(PlayerAttribute)baseParamId} was synced to {syncedValue}");
+                    }
+                }
+            }
+        }
+
+        return stats;
+    }
+
+    // This also works for Resistance Weapons
+    private Dictionary<int, int> GetMateriaStats(InventoryItem inventoryItem)
+    {
+        var stats = new Dictionary<int, int>();
+        var materiaSheet = Plugin.DataManager.GetExcelSheet<Materia>();
+
+        for (int i = 0; i < inventoryItem.Materia.Length; i++)
+        {
+            var materiaId = inventoryItem.Materia[i];
+
+            if (materiaId == 0 || !materiaSheet.TryGetRow(materiaId, out var materiaRow))
+            {
+                continue;
+            }
+
+            var index = inventoryItem.MateriaGrades[i];
+            var statValue = materiaRow.Value[index];
+            var stat = materiaRow.BaseParam.RowId;
+            stats[(int)stat] = statValue;
+        }
+
+        return stats;
+    }
+
+    // https://github.com/VioletStardustXIV/XivGearExport/blob/main/XivGearExport/XivGearSet.cs#L447
+    private Dictionary<int, int> GetMandervilleWeaponStats(InventoryItem inventoryItem)
+    {
+        var stats = new Dictionary<int, int>();
+
+        var statsSheet = Plugin.DataManager.GetExcelSheet<MandervilleWeaponEnhance>();
+        var materiaSheet = Plugin.DataManager.GetExcelSheet<Materia>();
+
+        if (!statsSheet.TryGetRow(inventoryItem.ItemId, out var _))
+        {
+            return stats;
+        }
+
+        for (int i = 0; i < inventoryItem.Materia.Length; i++)
+        {
+            var materiaId = inventoryItem.Materia[i];
+
+            if (materiaId == 0 || !materiaSheet.TryGetRow(materiaId, out var materiaRow))
+            {
+                continue;
+            }
+
+            var index = inventoryItem.MateriaGrades[i];
+            var statValue = materiaRow.Value[index];
+
+            switch (materiaId)
+            {
+                case 1403:
+                    stats[(int)PlayerAttribute.CriticalHit] = statValue;
+                    break;
+                case 1404:
+                    stats[(int)PlayerAttribute.DirectHitRate] = statValue;
+                    break;
+                case 1405:
+                    stats[(int)PlayerAttribute.Determination] = statValue;
+                    break;
+                case 1406:
+                    stats[(int)PlayerAttribute.SkillSpeed] = statValue;
+                    break;
+                case 1407:
+                    stats[(int)PlayerAttribute.SpellSpeed] = statValue;
+                    break;
+                case 1408:
+                    stats[(int)PlayerAttribute.Tenacity] = statValue;
+                    break;
+                case 1409:
+                    stats[(int)PlayerAttribute.Piety] = statValue;
+                    break;
+            }
+        }
+
+        return stats;
+    }
+
+    private void ApplyExtraStats(Dictionary<int, int> stats, Dictionary<int, int> extraStats)
+    {
+        foreach (var (attribute, value) in extraStats)
+        {
+            if (!stats.ContainsKey(attribute))
+            {
+                continue;
+            }
+
+            stats[attribute] += value;
         }
     }
 

--- a/AnoMech/Helpers/InstanceContentDirectorHelper.cs
+++ b/AnoMech/Helpers/InstanceContentDirectorHelper.cs
@@ -1,5 +1,8 @@
 using AnoMech.Pointers;
 using FFXIVClientStructs.FFXIV.Client.Game.Event;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using FFXIVClientStructs.FFXIV.Client.System.String;
+using Lumina.Excel.Sheets;
 using System;
 using System.Linq;
 
@@ -70,6 +73,51 @@ internal static unsafe class InstanceContentDirectorHelper
         {
             SetDirectorData(sequence, unk, unionDataPtr, (ulong)unionData.Length);
         }
+    }
+
+    public static void SetDutyData(ContentFinderCondition contentFinderCondition)
+    {
+        var eventFramework = EventFramework.Instance();
+
+        if (eventFramework == null)
+        {
+            Plugin.Log.Debug("[EventFrameworkHelper.SetDutyData] EventFramework.Instance() was null");
+            return;
+        }
+
+        var director = eventFramework->GetInstanceContentDirector();
+
+        if (director == null)
+        {
+            Plugin.Log.Debug("[EventFrameworkHelper.SetDutyData] eventFramework->GetInstanceContentDirector() was null");
+            return;
+        }
+
+        var uiState = UIState.Instance();
+
+        if (uiState == null)
+        {
+            Plugin.Log.Debug("[EventFrameworkHelper.SetDutyData] UIState.Instance() was null");
+            return;
+        }
+
+        var contentTypeRef = contentFinderCondition.ContentType;
+
+        if (contentTypeRef.IsValid)
+        {
+            director->ContentTypeRowId = (byte)contentFinderCondition.ContentType.RowId;
+            director->IconId = contentTypeRef.Value.IconDutyFinder;
+        }
+        else
+        {
+            Plugin.Log.Debug("[EventFrameworkHelper.SetDutyData] contentFinderCondition.ContentType was not valid, skipping director->ContentTypeRowId and director->IconId.");
+        }
+
+        using var str = new Utf8String(contentFinderCondition.Name);
+
+        director->Title.SetString(str);
+        uiState->DirectorTodo.Title.SetString(str);
+        uiState->DirectorTodo.IsShown = true;
     }
 
     // Fire the three DirectorUpdate events the server sends at instance Commence

--- a/AnoMech/Pointers/PacketDispatcherPointers.cs
+++ b/AnoMech/Pointers/PacketDispatcherPointers.cs
@@ -26,6 +26,17 @@ public partial struct DespawnCharacterPacket
     [FieldOffset(0x0)] public byte Index;
 }
 
+[StructLayout(LayoutKind.Explicit, Size = 0x10)]
+public partial struct UpdateClassInfoPacket
+{
+    [FieldOffset(0x0)] public byte ClassJobId;
+    [FieldOffset(0x2)] public ushort CurrentLevel;
+    [FieldOffset(0x4)] public ushort ClassJobLevel;
+    [FieldOffset(0x6)] public ushort SyncedLevel;
+    [FieldOffset(0x8)] public ushort ClassJobExp;
+    [FieldOffset(0xC)] public uint BaseRestedExperience;
+}
+
 internal unsafe class PacketDispatcherPointers
 {
     [Signature("40 53 57 48 81 EC ?? ?? ?? ?? 48 8B FA 8B", UseFlags = SignatureUseFlags.Pointer, ScanType = ScanType.Text)]
@@ -37,9 +48,14 @@ internal unsafe class PacketDispatcherPointers
     [Signature("48 89 5C 24 ?? 57 48 83 EC 40 0F B6 1A", UseFlags = SignatureUseFlags.Pointer, ScanType = ScanType.Text)]
     public static HandleDespawnCharacterPacketDelegate HandleDespawnCharacterPacket { get; private set; } = null!;
 
+    // Technically the real HandleUpdateClassInfoPacket is a wrapper to this sig... but this is still close to other HandleX methods, so it fits here
+    [Signature("48 89 5C 24 ?? 57 48 83 EC 20 48 8B DA 48 8D 0D ?? ?? ?? ?? 33", UseFlags = SignatureUseFlags.Pointer, ScanType = ScanType.Text)]
+    public static HandleUpdateClassInfoPacketDelegate HandleUpdateClassInfoPacket { get; private set; } = null!;
+
     public delegate void HandleActorCastPacketDelegate(uint entityId, ActorCastPacket* packet);
     public delegate void HandleDespawnObjectPacketDelegate(uint unused, byte* packet);
     public delegate void HandleDespawnCharacterPacketDelegate(ulong unused, DespawnCharacterPacket* packet);
+    public delegate void HandleUpdateClassInfoPacketDelegate(ulong unused, UpdateClassInfoPacket* packet);
 
     public static void Initialize()
     {

--- a/AnoMech/Scenarios/IScenario.cs
+++ b/AnoMech/Scenarios/IScenario.cs
@@ -15,13 +15,18 @@ public interface IScenario
     IReadOnlyList<Waymark> Waymarks => Array.Empty<Waymark>();
     ushort Bgm => 0;
     bool SupportsSolo => false;
+    byte Level => 0;
+    ushort ItemLevel => 0;
+
     // Scenario-local arena positions whose BG SharedGroup colliders should be
     // removed at scenario start (same mechanism as the spawn-ring barrier drop).
     IReadOnlyList<Vector3> ColliderRemovalPoints => Array.Empty<Vector3>();
+
     // Selectable AI strats, ordered. The main-window strat picker is shown only when
     // there is more than one. The user's choice is passed to Run as selectedAi.
     IReadOnlyList<IScenarioAi> AiStrats { get; }
     // selectedAi: index into AiStrats of the strat to run, or null for solo (no AI).
+
     void Run(SimWorld world, int? selectedAi);
     void Tick(float delta, float elapsed) { }
     void DrawSettings() { }

--- a/AnoMech/Scenarios/Top/P2PartySynergy/TopP2PartySynergyScenario.cs
+++ b/AnoMech/Scenarios/Top/P2PartySynergy/TopP2PartySynergyScenario.cs
@@ -21,6 +21,8 @@ public sealed class TopP2PartySynergyScenario : IScenario
     public IReadOnlyList<Waymark> Waymarks { get; } = TopUtils.TopWaymarks;
     public ushort Bgm => BgmId.TopP2;
     public bool SupportsSolo => true;
+    public byte Level => 90;
+    public ushort ItemLevel => 365;
 
     public void DrawSettings() => settingsWindow.Draw();
     private readonly TopP2PartySynergySettingsWindow settingsWindow = new();

--- a/AnoMech/Scenarios/Top/P5Delta/TopP5DeltaScenario.cs
+++ b/AnoMech/Scenarios/Top/P5Delta/TopP5DeltaScenario.cs
@@ -23,6 +23,8 @@ public sealed class TopP5DeltaScenario : IScenario
         WeatherId: 174);
     public IReadOnlyList<Waymark> Waymarks { get; } = TopUtils.TopWaymarks;
     public ushort Bgm => BgmId.TopP5;
+    public byte Level => 90;
+    public ushort ItemLevel => 365;
     public void DrawSettings() => settingsWindow.Draw();
     private readonly TopP5DeltaSettingsWindow settingsWindow = new();
 

--- a/AnoMech/Scenarios/Top/P5Omega/TopP5OmegaScenario.cs
+++ b/AnoMech/Scenarios/Top/P5Omega/TopP5OmegaScenario.cs
@@ -22,6 +22,8 @@ public sealed class TopP5OmegaScenario : IScenario
     public IReadOnlyList<Waymark> Waymarks { get; } = TopUtils.TopWaymarks;
     public ushort Bgm => BgmId.TopP5;
     public bool SupportsSolo => true;
+    public byte Level => 90;
+    public ushort ItemLevel => 365;
 
     private SimWorld world = null!;
     private SimParty party = null!;

--- a/AnoMech/Scenarios/Top/P5Sigma/TopP5SigmaScenario.cs
+++ b/AnoMech/Scenarios/Top/P5Sigma/TopP5SigmaScenario.cs
@@ -23,6 +23,8 @@ public sealed class TopP5SigmaScenario : IScenario
     public IReadOnlyList<Waymark> Waymarks { get; } = TopUtils.TopWaymarks;
 
     public ushort Bgm => BgmId.TopP5;
+    public byte Level => 90;
+    public ushort ItemLevel => 365;
 
     public void DrawSettings() => settingsWindow.Draw();
     private readonly TopP5SigmaSettingsWindow settingsWindow = new();

--- a/AnoMech/Scenarios/Top/P6WaveCannon2/TopP6WaveCannon2Scenario.cs
+++ b/AnoMech/Scenarios/Top/P6WaveCannon2/TopP6WaveCannon2Scenario.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -24,11 +24,12 @@ public sealed class TopP6WaveCannon2Scenario : IScenario
     public IReadOnlyList<Waymark> Waymarks { get; } = TopUtils.TopWaymarks;
 
     public ushort Bgm => BgmId.TopP6;
+    public bool SupportsSolo => true;
+    public byte Level => 90;
+    public ushort ItemLevel => 365;
 
     public void DrawSettings() => settingsWindow.Draw();
     private readonly TopP6WaveCannon2SettingsWindow settingsWindow = new();
-
-    public bool SupportsSolo => true;
 
     public IReadOnlyList<IScenarioAi> AiStrats => [new TopP6WaveCannon2Ai()];
 


### PR DESCRIPTION
This PR adds the following things:
- `Duty Information` is now properly filled with the information it expects and renders properly.
- Level Sync
- Item Level Sync **(Partial, only affects _Skill Speed_ and _Spell Speed_ as of now)**

To allow for these additions, these additions have been made:
- `InstanceContentDirectorHelper.SetDutyData()` has been added, which sets the Duty data to the Director and the Director in the UI, allowing to see the Duty Name, Icon and Time once inside.
- This new method is used in `ZoneSession.LoadZoneInternal()`, on Step 3 specifically. And, the revert process is done at Step 1.
- `IScenario.Level` and `IScenario.ItemLevel` optional parameters were added, which allow to setup the Level/Item Level values used to sync. If 0 (default value), the respective parameter will not be used for syncing.
- `PacketDispatcherPointers.HandleUpdateClassInfoPacket` has been added, alongside it's `UpdateClassInfoPacket` struct. This Packet is responsible for setting the Level Sync on the Player.
- `ZoneSession.GetSyncedAttributes()` has been added, which gets the Item Level synced Player attributes **(only supports _Skill Speed_ and _Spell Speed_ as of now)**.
- This new Pointer and method are used in the new methods `ZoneSession.SetSync()` and `ZoneSession.ResetSync()`, which are called when initializing the Director, and when finalizing it, respectively.
- `ZoneSession.SessionSave` is a new class added to organize the saved values, instead of having them floating around as properties (that grew because of these changes).

And, a small bugfix:
- `ZoneSession.LoadZoneInternal()` Step 3 is skipped if we are reverting, preventing the creation of a ghost Director. There's no need to create one as we're exiting to a Director-less place, which is assumed anyways because a Director is created to enter the Scenario in the first place.

**Why only _Skill Speed_ and _Spell Speed_ are supported for Item Level Sync?:** Because, calculating most of the other values require doing more complex lookups, like getting Race stats, Job stats, etc. The main point of this addition is to simulate Cast times properly for legacy (synced) content, adding more value to the user's experience practicing.