### PR TITLE
Add 2 EU Forsaken strats, region picker and waymark dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vs/
 obj/
 /logs/
+/docs/
 /Reference/
 bin/
 .idea/

--- a/AnoMech/Core/Game/Ai/IScenarioAi.cs
+++ b/AnoMech/Core/Game/Ai/IScenarioAi.cs
@@ -12,6 +12,11 @@ namespace AnoMech.Core.Game.Ai;
 public interface IScenarioAi
 {
     string Name { get; }
+
+    // Optional region/group this strat belongs to. Used by the main-window strat
+    // picker to bucket strats under region buttons; must match one of the scenario's
+    // IScenario.StratGroups. Null = ungrouped (scenario shows no region row).
+    string? Group => null;
 }
 
 public interface IScenarioAi<TState> : IScenarioAi

--- a/AnoMech/Core/Game/Game.cs
+++ b/AnoMech/Core/Game/Game.cs
@@ -73,12 +73,23 @@ public sealed class Game : IDisposable
 
     // selectedAi: index into the scenario's AiStrats of the strat to run, or null for
     // solo (no doppels, no AI). Defaults to 0 = run the first strat with a full party.
-    public void RunScenario(IScenario scenario, PartyRole? roleOverride = null, int? selectedAi = 0)
+    // selectedWaymark: index into the scenario's WaymarkPresets; ignored when it has none.
+    public void RunScenario(IScenario scenario, PartyRole? roleOverride = null, int? selectedAi = 0, int selectedWaymark = 0)
     {
-        Plugin.Framework.Run(() => RunScenarioInternal(scenario, roleOverride, selectedAi));
+        Plugin.Framework.Run(() => RunScenarioInternal(scenario, roleOverride, selectedAi, selectedWaymark));
     }
 
-    private void RunScenarioInternal(IScenario scenario, PartyRole? roleOverride, int? selectedAi)
+    // The waymark layout to place: the selected preset when the scenario defines any,
+    // otherwise the scenario's default Waymarks (back-compat for preset-less scenarios).
+    private static IReadOnlyList<Waymark> ResolveWaymarks(IScenario scenario, int selectedWaymark)
+    {
+        var presets = scenario.WaymarkPresets;
+        if (presets.Count > 0 && selectedWaymark >= 0 && selectedWaymark < presets.Count)
+            return presets[selectedWaymark].Markers;
+        return scenario.Waymarks;
+    }
+
+    private void RunScenarioInternal(IScenario scenario, PartyRole? roleOverride, int? selectedAi, int selectedWaymark)
     {
         var solo = selectedAi is null;
         // Hard gate: scenarios are only ever run from an inn. Everything
@@ -107,7 +118,7 @@ public sealed class Game : IDisposable
         World.Map.TryLoad(scenario.TargetInstance, scenario.Level, scenario.ItemLevel);
         World.ScenarioOrigin = scenario.TargetInstance.Origin;
         World.Map.ArmColliderDrops(scenario.ColliderRemovalPoints.Select(World.Coordinates.ToGlobal));
-        World.PlaceWaymarks(scenario.Waymarks);
+        World.PlaceWaymarks(ResolveWaymarks(scenario, selectedWaymark));
         World.CreateParty(player.ClassJob.RowId, roleOverride, solo);
         scenario.Run(World, selectedAi);   // creates the SimArenaBoundary the out-of-arena check reads
         // Entering the zone always starts at spawn; a restart only recenters the player

--- a/AnoMech/Core/Game/Waymarks.cs
+++ b/AnoMech/Core/Game/Waymarks.cs
@@ -13,6 +13,10 @@ public enum WaymarkSlot : int
 
 public sealed record Waymark(WaymarkSlot Slot, Vector3 Offset);
 
+// A named waymark layout, selectable in the main window's "Waymarks:" dropdown.
+// Markers are scenario-local offsets, same frame as Waymark.Offset.
+public sealed record WaymarkLayout(string Name, IReadOnlyList<Waymark> Markers);
+
 public static class WaymarkPresets
 {
     // Ring of A,1,B,2,C,3,D,4 spaced 45° apart, A at north going clockwise.

--- a/AnoMech/Plugin.cs
+++ b/AnoMech/Plugin.cs
@@ -220,6 +220,11 @@ public sealed class Plugin : IDalamudPlugin
             Log.Warning($"{scenario.Name} does not support Solo mode.");
             return;
         }
+        if (!solo && MainWindow.SelectedStrat < 0)
+        {
+            Log.Warning("No strat selected for the current region.");
+            return;
+        }
         Game.RunScenario(scenario, MainWindow.SelectedRoleOverride, solo ? null : MainWindow.SelectedStrat);
     }
 

--- a/AnoMech/Plugin.cs
+++ b/AnoMech/Plugin.cs
@@ -225,7 +225,7 @@ public sealed class Plugin : IDalamudPlugin
             Log.Warning("No strat selected for the current region.");
             return;
         }
-        Game.RunScenario(scenario, MainWindow.SelectedRoleOverride, solo ? null : MainWindow.SelectedStrat);
+        Game.RunScenario(scenario, MainWindow.SelectedRoleOverride, solo ? null : MainWindow.SelectedStrat, MainWindow.SelectedWaymark);
     }
 
     public void ToggleConfigUi() => ConfigWindow.Toggle();

--- a/AnoMech/Scenarios/IScenario.cs
+++ b/AnoMech/Scenarios/IScenario.cs
@@ -30,6 +30,11 @@ public interface IScenario
     // When non-empty, the picker filters AiStrats by IScenarioAi.Group and lists only
     // the selected region's strats. Empty (default) = no region row; all strats listed.
     IReadOnlyList<string> StratGroups => Array.Empty<string>();
+
+    // Selectable named waymark layouts. When non-empty, the main window shows a
+    // "Waymarks:" dropdown below the strat picker and the chosen layout is placed
+    // instead of Waymarks. Empty (default) = no dropdown; Waymarks is used as before.
+    IReadOnlyList<WaymarkLayout> WaymarkPresets => Array.Empty<WaymarkLayout>();
     // selectedAi: index into AiStrats of the strat to run, or null for solo (no AI).
 
     void Run(SimWorld world, int? selectedAi);

--- a/AnoMech/Scenarios/IScenario.cs
+++ b/AnoMech/Scenarios/IScenario.cs
@@ -25,6 +25,11 @@ public interface IScenario
     // Selectable AI strats, ordered. The main-window strat picker is shown only when
     // there is more than one. The user's choice is passed to Run as selectedAi.
     IReadOnlyList<IScenarioAi> AiStrats { get; }
+
+    // Optional ordered region/group labels shown as buttons above the strat dropdown.
+    // When non-empty, the picker filters AiStrats by IScenarioAi.Group and lists only
+    // the selected region's strats. Empty (default) = no region row; all strats listed.
+    IReadOnlyList<string> StratGroups => Array.Empty<string>();
     // selectedAi: index into AiStrats of the strat to run, or null for solo (no AI).
 
     void Run(SimWorld world, int? selectedAi);

--- a/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenKroxyRinonAi.cs
+++ b/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenKroxyRinonAi.cs
@@ -8,6 +8,7 @@ namespace AnoMech.Scenarios.Umad.P2Forsaken.Ai;
 public sealed class UmadP2ForsakenKroxyRinonAi : IScenarioAi<UmadP2ForsakenState>
 {
     public string Name => "Kroxy-Rinon 341 (melee flex)";
+    public string? Group => "NA";
 
     public void Run(UmadP2ForsakenState state, SimWorld world)
         => new UmadP2ForsakenRinonAiHelper(

--- a/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenKroxyRinonOldAi.cs
+++ b/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenKroxyRinonOldAi.cs
@@ -6,6 +6,7 @@ namespace AnoMech.Scenarios.Umad.P2Forsaken.Ai;
 public sealed class UmadP2ForsakenKroxyRinonOldAi : IScenarioAi<UmadP2ForsakenState>
 {
     public string Name => "[old positions] Kroxy-Rinon 341 (melee flex)";
+    public string? Group => "NA";
 
     public void Run(UmadP2ForsakenState state, SimWorld world)
         => new UmadP2ForsakenRinonAiHelper(

--- a/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenP3ZBuddyMeowAi.cs
+++ b/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenP3ZBuddyMeowAi.cs
@@ -1,0 +1,19 @@
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.SimObjects;
+
+namespace AnoMech.Scenarios.Umad.P2Forsaken.Ai;
+
+// EU strat: forked from the NA "Kroxy-Rinon 341 (melee flex)" strat. Runs over its own
+// helper (UmadP2ForsakenP3ZBuddyMeowAiHelper) with hand-placed positions and a first-tower
+// stack-spot rule, diverging from the NA version without affecting it.
+public sealed class UmadP2ForsakenP3ZBuddyMeowAi : IScenarioAi<UmadP2ForsakenState>
+{
+    public string Name => "p3Z Buddy Meow";
+    public string? Group => "EU";
+
+    public void Run(UmadP2ForsakenState state, SimWorld world)
+        => new UmadP2ForsakenP3ZBuddyMeowAiHelper(
+               UmadP2ForsakenP3ZBuddyMeowAiHelper.StandardOdd,
+               UmadP2ForsakenP3ZBuddyMeowAiHelper.DiamonMarkersEven,
+               UmadP2ForsakenP3ZBuddyMeowAiHelper.KroxyReorder).Run(state, world);
+}

--- a/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenP3ZBuddyMeowAiHelper.cs
+++ b/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenP3ZBuddyMeowAiHelper.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.Game.Party;
+using AnoMech.Core.SimObjects;
+using static AnoMech.Scenarios.Umad.UmadConstants;
+
+namespace AnoMech.Scenarios.Umad.P2Forsaken.Ai;
+
+// Movement choreography for the EU "p3Z Buddy Meow" strat — an isolated fork of the NA
+// "Kroxy-Rinon 341 (melee flex)" helper (UmadP2ForsakenRinonAiHelper), free to diverge
+// without touching the shared NA helper. See that helper for the framework design notes.
+public sealed class UmadP2ForsakenP3ZBuddyMeowAiHelper
+{
+    private readonly Vector2?[] oddCoords;
+    private readonly Vector2?[] evenCoords;
+    private readonly Action<UmadP2ForsakenP3ZBuddyMeowAiHelper, int, IList<PartyRole>> reorderActive;
+
+    private UmadP2ForsakenState state = null!;
+
+    private IReadOnlyList<PartyRole> alphaInitial = [];
+    private IReadOnlyList<PartyRole> betaInitial = [];
+    private List<PartyRole> alpha = [];
+    private List<PartyRole> beta = [];
+
+    public UmadP2ForsakenP3ZBuddyMeowAiHelper(
+        Vector2?[] oddCoords,
+        Vector2?[] evenCoords,
+        Action<UmadP2ForsakenP3ZBuddyMeowAiHelper, int, IList<PartyRole>> reorderActive)
+    {
+        this.oddCoords = oddCoords;
+        this.evenCoords = evenCoords;
+        this.reorderActive = reorderActive;
+    }
+
+    public void Run(UmadP2ForsakenState s, SimWorld world)
+    {
+        state = s;
+        var ai = new AiManager(world);
+        Init();
+
+        ai.Move(1f, InitialLineup);
+        ai.Move(10.16f, TowerPositions(0), jitter: .0f, arrivalTime: 22.16f);
+        ai.Move(25.17f, TowerPositions(1), jitter: .0f, arrivalTime: 32.16f);
+        ai.Move(33f, AllThingsEndsBait(0), arrivalTime: 37f);
+        ai.Move(39.21f, TowerPositions(2), jitter: .0f, arrivalTime: 43.21f);
+        ai.Move(47.22f, TowerPositions(3), jitter: .0f, arrivalTime: 53.22f);
+        ai.Move(54f, AllThingsEndsBait(1), arrivalTime: 57f);
+        ai.Move(59.26f, TowerPositions(4), jitter: .0f, arrivalTime: 63.86f);
+        ai.Move(65.27f, TowerPositions(5), jitter: .0f, arrivalTime: 73.27f);
+        ai.Move(75f, AllThingsEndsBait(2), arrivalTime: 78f);
+        ai.Move(79.31f, TowerPositions(6), jitter: .0f, arrivalTime: 83.8f);
+        ai.Move(90.32f, TowerPositions(7), jitter: .0f, arrivalTime: 94.32f);
+    }
+
+    private Func<IAiMove> AllThingsEndsBait(int i)
+    {
+        return () => AiMove.All(new(0, 0)) // they actually dont bait anything, leave it for player to bait
+                           .ApplyPositions(AdjustForFuture(i), state.NewNorthAt(2 * i + 2).Apply);
+    }
+
+    private Action<IAiPositions> AdjustForFuture(int i)
+    {
+        return pos =>
+        {
+            if (state.EndAttacks[i] == EndAttack.PastsEnd)
+                pos.Multiply(-1);
+        };
+    }
+
+    private void Init()
+    {
+        var stacks = state.Lockons.Where(pair => pair.Value == LockonId.ForsakenStack).Select(pair => pair.Key)
+                          .ToList();
+        var supportPair = (PartyRole)(((int)stacks[0] + 2) % 4);
+        var dpsPair = (PartyRole)((((int)stacks[1] - 2) % 4) + 4);
+        var list = new List<PartyRole>([stacks[0], stacks[1], supportPair, dpsPair]);
+        list.Sort();
+        (list[0], list[1]) = (list[1], list[0]); // swap tank and healer
+        alpha = list;
+        alphaInitial = new List<PartyRole>(alpha);
+        list = Enum.GetValues<PartyRole>()
+                   .Where(role => !list.Contains(role))
+                   .ToList();
+        (list[0], list[1]) = (list[1], list[0]); // swap tank and healer
+        beta = list;
+        betaInitial = new List<PartyRole>(beta);
+    }
+
+
+    public PartyRole ActiveRole(uint mechanic, int towerId, int order)
+    {
+        var array = towerId is < 3 or 7 ? alpha : beta;
+        try
+        {
+            return array
+                   .Where(role => state.Lockons[role] == mechanic)
+                   .Skip(order)
+                   .First();
+        }
+        catch (InvalidOperationException)
+        {
+            Plugin.Log.Warning($"Lockons {string.Join(",", state.Lockons)}");
+            Plugin.Log.Warning($"Can't find {mechanic}.{order}, for {towerId}, for {string.Join(",", array)}");
+            throw;
+        }
+    }
+
+    private PartyRole PassiveRole(int towerId, int order)
+    {
+        var array = towerId is < 3 or 7 ? betaInitial : alphaInitial;
+        return array[order];
+    }
+
+    private IAiMove InitialLineup()
+    {
+        return AiMove.Create(
+            new(-6.2f, -1.7f),  // MT (mirror of M1)
+            new(-5.4f, 3.3f),   // OT (mirror of M2)
+            new(-5.4f, -3.6f),  // H1 (mirror of R1)
+            new(-3.1f, 5.3f),   // H2 (mirror of R2)
+            new(6.2f, -1.7f),   // M1
+            new(5.4f, 3.3f),    // M2
+            new(5.4f, -3.6f),   // R1
+            new(3.1f, 5.3f)     // R2
+        );
+    }
+
+    private Func<IAiMove> TowerPositions(int i)
+    {
+        return () =>
+        {
+            var move = i % 2 == 1 ? EvenTower(i) : OddTower(i); // odd/even flipped because 0 indexing teehee
+            reorderActive(this, i, i is < 3 or 7 ? alpha : beta); // plug point: same active-group rule as ActiveRole
+            return move;
+        };
+    }
+
+    private IAiMove OddTower(int i)
+    {
+        var (rightStack, leftStack) = StackSpots(i);
+        return AiMove.Create(oddCoords)
+                     .Assignments([
+                         rightStack,
+                         ActiveRole(LockonId.ForsakenCone, i, 0),
+                         leftStack,
+                         ActiveRole(LockonId.ForsakenChariot, i, 0),
+                         PassiveRole(i, 0),
+                         PassiveRole(i, 1),
+                         PassiveRole(i, 2),
+                         PassiveRole(i, 3)
+                     ])
+                     .ApplyPositions(state.NewNorthAt(i).Apply);
+    }
+
+    // Which stack-holder takes the right [0] spot vs the left [2] spot on an S tower.
+    // First tower set only (i == 0): the cone group's stack-holder takes the right spot,
+    // the chariot group's stack-holder the left. Every later tower reverts to the standard
+    // alpha-order ruling (#0 -> right, #1 -> left). This is the p3Z Buddy Meow change; the
+    // reorder plug-point can't express it because it fires after each tower's move is built.
+    private (PartyRole right, PartyRole left) StackSpots(int i)
+    {
+        var first = ActiveRole(LockonId.ForsakenStack, i, 0);
+        var second = ActiveRole(LockonId.ForsakenStack, i, 1);
+        if (i != 0) return (first, second);
+        return GroupLockon(first) == LockonId.ForsakenCone ? (first, second) : (second, first);
+    }
+
+    // The Cone/Chariot telegraph carried by stackRole's group (supports = roles 0-3,
+    // DPS = 4-7). The stack-holder's own lockon is Stack, so read a same-group non-stack
+    // member to recover whether that group drew cones or chariots.
+    private uint GroupLockon(PartyRole stackRole)
+    {
+        var support = (int)stackRole < 4;
+        foreach (var (role, lockon) in state.Lockons)
+            if (((int)role < 4) == support && lockon != LockonId.ForsakenStack)
+                return lockon;
+        return 0;
+    }
+
+    private IAiMove EvenTower(int i)
+    {
+        return AiMove.Create(evenCoords)
+                     .Assignments([
+                         ActiveRole(LockonId.ForsakenCone, i, 0),
+                         ActiveRole(LockonId.ForsakenChariot, i, 0),
+                         ActiveRole(LockonId.ForsakenCone, i, 1),
+                         ActiveRole(LockonId.ForsakenChariot, i, 1),
+                         PassiveRole(i, 0),
+                         PassiveRole(i, 1),
+                         PassiveRole(i, 2),
+                         PassiveRole(i, 3),
+                     ])
+                     .ApplyPositions(state.NewNorthAt(i).Apply);
+    }
+
+    // --- Coordinate sets ---
+    // 16 scenario-local XZ coords per set: 8 for odd-index towers, 8 for even-index
+    // towers (active 4 + passive 4 each). Passed into the constructor by the strats.
+    // AiMove copies these on Create, so its per-move rotation never mutates the set.
+
+    // EU "p3Z Buddy Meow" S-tower layout — hand-placed spots (authoring frame, north up).
+    // 4 active (stack/cone/stack/chariot) + 4 passive baits; [6]/[7] share one in-stack spot.
+    public static readonly Vector2?[] StandardOdd =
+    [
+        // active group
+        new(4.8f, -4.4f),   // right stack
+        new(3.3f, -8.4f),   // right cone
+        new(-2.9f, -7.3f),  // left stack
+        new(-7.7f, -2.6f),  // left chariot
+        // passive group
+        new(4.1f, -10.2f),  // right cone baiter
+        new(1.5f, -2.7f),   // right stack baiter
+        new(-1.6f, -8.3f),  // left stack baiter
+        new(-1.6f, -8.3f)   // left stack baiter (shares spot)
+    ];
+
+    public static readonly Vector2?[] DiamonMarkersEven =
+    [
+        // active group
+        new(4.8f, -2.2f),  // cone1
+        new(6.3f, -9.2f),  // chariot1
+        new(-4.8f, -2.2f), // cone2
+        new(-6.3f, -9.2f), // chariot2
+        // passive group
+        new(10.5f, 0f),  // cone bait1
+        new(3.5f, 4.9f),   // clone bait1
+        new(-3.5f, 4.9f),  // clone bait2
+        new(-10.5f, 0f)  // cone bait2
+    ];
+
+    // --- Reorder behavior ---
+    // The strat's per-tower plug point, invoked from TowerPositions with the helper
+    // instance + the active 4-role group. p3Z Buddy Meow doesn't reorder (no-op); the
+    // first-tower stack swap lives in StackSpots instead.
+    public static void KroxyReorder(UmadP2ForsakenP3ZBuddyMeowAiHelper helper, int index, IList<PartyRole> active)
+    {
+    }
+}

--- a/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenSouthFlex341OldAi.cs
+++ b/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenSouthFlex341OldAi.cs
@@ -6,6 +6,7 @@ namespace AnoMech.Scenarios.Umad.P2Forsaken.Ai;
 public sealed class UmadP2ForsakenSouthFlex341OldAi : IScenarioAi<UmadP2ForsakenState>
 {
     public string Name => "[old positions] South Flex 341";
+    public string? Group => "NA";
 
     public void Run(UmadP2ForsakenState state, SimWorld world)
         => new UmadP2ForsakenRinonAiHelper(

--- a/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenSouthFlexAi.cs
+++ b/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenSouthFlexAi.cs
@@ -8,6 +8,7 @@ namespace AnoMech.Scenarios.Umad.P2Forsaken.Ai;
 public sealed class UmadP2ForsakenSouthFlexAi : IScenarioAi<UmadP2ForsakenState>
 {
     public string Name => "South Flex 341";
+    public string? Group => "NA";
 
     public void Run(UmadP2ForsakenState state, SimWorld world)
         => new UmadP2ForsakenRinonAiHelper(

--- a/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenZP6SouthAdjustAi.cs
+++ b/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenZP6SouthAdjustAi.cs
@@ -1,0 +1,19 @@
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.SimObjects;
+
+namespace AnoMech.Scenarios.Umad.P2Forsaken.Ai;
+
+// EU strat: isolated copy of the NA "South Flex 341" strat. Runs over its own forked
+// helper (UmadP2ForsakenZP6SouthAdjustAiHelper) so it can diverge from the NA version
+// without affecting it.
+public sealed class UmadP2ForsakenZP6SouthAdjustAi : IScenarioAi<UmadP2ForsakenState>
+{
+    public string Name => "zP6 South adjust";
+    public string? Group => "EU";
+
+    public void Run(UmadP2ForsakenState state, SimWorld world)
+        => new UmadP2ForsakenZP6SouthAdjustAiHelper(
+               UmadP2ForsakenZP6SouthAdjustAiHelper.StandardOdd,
+               UmadP2ForsakenZP6SouthAdjustAiHelper.DiamonMarkersEven,
+               UmadP2ForsakenZP6SouthAdjustAiHelper.SouthFlexReorder).Run(state, world);
+}

--- a/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenZP6SouthAdjustAiHelper.cs
+++ b/AnoMech/Scenarios/Umad/P2Forsaken/Ai/UmadP2ForsakenZP6SouthAdjustAiHelper.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.Game.Party;
+using AnoMech.Core.SimObjects;
+using static AnoMech.Scenarios.Umad.UmadConstants;
+
+namespace AnoMech.Scenarios.Umad.P2Forsaken.Ai;
+
+// Movement choreography for the EU "zP6 South adjust" strat — an isolated fork of the NA
+// "South Flex 341" helper (UmadP2ForsakenRinonAiHelper), free to diverge without touching
+// the shared NA helper. See that helper for the framework design notes.
+public sealed class UmadP2ForsakenZP6SouthAdjustAiHelper
+{
+    private readonly Vector2?[] oddCoords;
+    private readonly Vector2?[] evenCoords;
+    private readonly Action<UmadP2ForsakenZP6SouthAdjustAiHelper, int, IList<PartyRole>> reorderActive;
+
+    private UmadP2ForsakenState state = null!;
+
+    private IReadOnlyList<PartyRole> alphaInitial = [];
+    private IReadOnlyList<PartyRole> betaInitial = [];
+    private List<PartyRole> alpha = [];
+    private List<PartyRole> beta = [];
+
+    public UmadP2ForsakenZP6SouthAdjustAiHelper(
+        Vector2?[] oddCoords,
+        Vector2?[] evenCoords,
+        Action<UmadP2ForsakenZP6SouthAdjustAiHelper, int, IList<PartyRole>> reorderActive)
+    {
+        this.oddCoords = oddCoords;
+        this.evenCoords = evenCoords;
+        this.reorderActive = reorderActive;
+    }
+
+    public void Run(UmadP2ForsakenState s, SimWorld world)
+    {
+        state = s;
+        var ai = new AiManager(world);
+        Init();
+
+        ai.Move(1f, InitialLineup);
+        ai.Move(10.16f, TowerPositions(0), jitter: .0f, arrivalTime: 22.16f);
+        ai.Move(25.17f, TowerPositions(1), jitter: .0f, arrivalTime: 32.16f);
+        ai.Move(33f, AllThingsEndsBait(0), arrivalTime: 37f);
+        ai.Move(39.21f, TowerPositions(2), jitter: .0f, arrivalTime: 43.21f);
+        ai.Move(47.22f, TowerPositions(3), jitter: .0f, arrivalTime: 53.22f);
+        ai.Move(54f, AllThingsEndsBait(1), arrivalTime: 57f);
+        ai.Move(59.26f, TowerPositions(4), jitter: .0f, arrivalTime: 63.86f);
+        ai.Move(65.27f, TowerPositions(5), jitter: .0f, arrivalTime: 73.27f);
+        ai.Move(75f, AllThingsEndsBait(2), arrivalTime: 78f);
+        ai.Move(79.31f, TowerPositions(6), jitter: .0f, arrivalTime: 83.8f);
+        ai.Move(90.32f, TowerPositions(7), jitter: .0f, arrivalTime: 94.32f);
+    }
+
+    private Func<IAiMove> AllThingsEndsBait(int i)
+    {
+        return () => AiMove.All(new(0, 0)) // they actually dont bait anything, leave it for player to bait
+                           .ApplyPositions(AdjustForFuture(i), state.NewNorthAt(2 * i + 2).Apply);
+    }
+
+    private Action<IAiPositions> AdjustForFuture(int i)
+    {
+        return pos =>
+        {
+            if (state.EndAttacks[i] == EndAttack.PastsEnd)
+                pos.Multiply(-1);
+        };
+    }
+
+    private void Init()
+    {
+        var stacks = state.Lockons.Where(pair => pair.Value == LockonId.ForsakenStack).Select(pair => pair.Key)
+                          .ToList();
+        var supportPair = (PartyRole)(((int)stacks[0] + 2) % 4);
+        var dpsPair = (PartyRole)((((int)stacks[1] - 2) % 4) + 4);
+        var list = new List<PartyRole>([stacks[0], stacks[1], supportPair, dpsPair]);
+        list.Sort();
+        (list[0], list[1]) = (list[1], list[0]); // swap tank and healer
+        alpha = list;
+        alphaInitial = new List<PartyRole>(alpha);
+        list = Enum.GetValues<PartyRole>()
+                   .Where(role => !list.Contains(role))
+                   .ToList();
+        (list[0], list[1]) = (list[1], list[0]); // swap tank and healer
+        beta = list;
+        betaInitial = new List<PartyRole>(beta);
+    }
+
+
+    public PartyRole ActiveRole(uint mechanic, int towerId, int order)
+    {
+        var array = towerId is < 3 or 7 ? alpha : beta;
+        try
+        {
+            return array
+                   .Where(role => state.Lockons[role] == mechanic)
+                   .Skip(order)
+                   .First();
+        }
+        catch (InvalidOperationException)
+        {
+            Plugin.Log.Warning($"Lockons {string.Join(",", state.Lockons)}");
+            Plugin.Log.Warning($"Can't find {mechanic}.{order}, for {towerId}, for {string.Join(",", array)}");
+            throw;
+        }
+    }
+
+    private PartyRole PassiveRole(int towerId, int order)
+    {
+        var array = towerId is < 3 or 7 ? betaInitial : alphaInitial;
+        return array[order];
+    }
+
+    private IAiMove InitialLineup()
+    {
+        return AiMove.Create(
+            new(-6.2f, -1.7f),  // MT (mirror of M1)
+            new(-5.4f, 3.3f),   // OT (mirror of M2)
+            new(-5.4f, -3.6f),  // H1 (mirror of R1)
+            new(-3.1f, 5.3f),   // H2 (mirror of R2)
+            new(6.2f, -1.7f),   // M1
+            new(5.4f, 3.3f),    // M2
+            new(5.4f, -3.6f),   // R1
+            new(3.1f, 5.3f)     // R2
+        );
+    }
+
+    private Func<IAiMove> TowerPositions(int i)
+    {
+        return () =>
+        {
+            var move = i % 2 == 1 ? EvenTower(i) : OddTower(i); // odd/even flipped because 0 indexing teehee
+            reorderActive(this, i, i is < 3 or 7 ? alpha : beta); // plug point: same active-group rule as ActiveRole
+            return move;
+        };
+    }
+
+    private IAiMove OddTower(int i)
+    {
+        return AiMove.Create(oddCoords)
+                     .Assignments([
+                         ActiveRole(LockonId.ForsakenStack, i, 0),
+                         ActiveRole(LockonId.ForsakenCone, i, 0),
+                         ActiveRole(LockonId.ForsakenStack, i, 1),
+                         ActiveRole(LockonId.ForsakenChariot, i, 0),
+                         PassiveRole(i, 0),
+                         PassiveRole(i, 1),
+                         PassiveRole(i, 2),
+                         PassiveRole(i, 3)
+                     ])
+                     .ApplyPositions(state.NewNorthAt(i).Apply);
+    }
+
+    private IAiMove EvenTower(int i)
+    {
+        return AiMove.Create(evenCoords)
+                     .Assignments([
+                         ActiveRole(LockonId.ForsakenCone, i, 0),
+                         ActiveRole(LockonId.ForsakenChariot, i, 0),
+                         ActiveRole(LockonId.ForsakenCone, i, 1),
+                         ActiveRole(LockonId.ForsakenChariot, i, 1),
+                         PassiveRole(i, 0),
+                         PassiveRole(i, 1),
+                         PassiveRole(i, 2),
+                         PassiveRole(i, 3),
+                     ])
+                     .ApplyPositions(state.NewNorthAt(i).Apply);
+    }
+
+    // --- Coordinate sets ---
+    // 16 scenario-local XZ coords per set: 8 for odd-index towers, 8 for even-index
+    // towers (active 4 + passive 4 each). Passed into the constructor by the strats.
+    // AiMove copies these on Create, so its per-move rotation never mutates the set.
+
+    // S-tower layout — borrowed verbatim from the EU "p3Z Buddy Meow" StandardOdd spots
+    // (authoring frame, north up). 4 active (stack/cone/stack/chariot) + 4 passive baits;
+    // [6]/[7] share one in-stack spot.
+    public static readonly Vector2?[] StandardOdd =
+    [
+        // active group
+        new(4.8f, -4.4f),   // right stack
+        new(3.3f, -8.4f),   // right cone
+        new(-2.9f, -7.3f),  // left stack
+        new(-7.7f, -2.6f),  // left chariot
+        // passive group
+        new(4.1f, -10.2f),  // right cone baiter
+        new(1.5f, -2.7f),   // right stack baiter
+        new(-1.6f, -8.3f),  // left stack baiter
+        new(-1.6f, -8.3f)   // left stack baiter (shares spot)
+    ];
+
+    public static readonly Vector2?[] DiamonMarkersEven =
+    [
+        // active group
+        new(4.8f, -2.2f),  // cone1
+        new(6.3f, -9.2f),  // chariot1
+        new(-4.8f, -2.2f), // cone2
+        new(-6.3f, -9.2f), // chariot2
+        // passive group
+        new(10.5f, 0f),  // cone bait1
+        new(3.5f, 4.9f),   // clone bait1
+        new(-3.5f, 4.9f),  // clone bait2
+        new(-10.5f, 0f)  // cone bait2
+    ];
+
+    // --- Reorder behavior ---
+    // The strat's per-tower plug point, invoked from TowerPositions with the helper
+    // instance + the active 4-role group.
+
+    // zP6 South adjust: South Flex's S-tower reorder with the left pair swapped so the
+    // left stack leads the left chariot (right side matches South Flex — right stack over
+    // right cone). The carried order is then the S-tower's own spot order:
+    // right stack > right cone > left stack > left chariot. Next tower, within each mechanic
+    // the earlier-ranked player takes the right spot (no side-preservation guarantee — e.g.
+    // a left stack can rank ahead of a left chariot and cross to a right spot). The only
+    // divergence from NA South Flex; CC towers unchanged.
+    public static void SouthFlexReorder(UmadP2ForsakenZP6SouthAdjustAiHelper helper, int index, IList<PartyRole> active)
+    {
+        if (index % 2 == 0) // odd tower
+        {
+            List<PartyRole> reordered =
+            [
+                helper.ActiveRole(LockonId.ForsakenStack, index, 0),   // right stack
+                helper.ActiveRole(LockonId.ForsakenCone, index, 0),    // right cone
+                helper.ActiveRole(LockonId.ForsakenStack, index, 1),   // left stack
+                helper.ActiveRole(LockonId.ForsakenChariot, index, 0)  // left chariot
+            ];
+            active.Clear();
+            reordered.ForEach(active.Add);
+        }
+        else // even tower
+        {
+            List<PartyRole> reordered =
+            [
+                helper.ActiveRole(LockonId.ForsakenCone, index, 0),
+                helper.ActiveRole(LockonId.ForsakenChariot, index, 0),
+                helper.ActiveRole(LockonId.ForsakenChariot, index, 1),
+                helper.ActiveRole(LockonId.ForsakenCone, index, 1)
+            ];
+            active.Clear();
+            reordered.ForEach(active.Add);
+        }
+    }
+}

--- a/AnoMech/Scenarios/Umad/P2Forsaken/UmadP2ForsakenScenario.cs
+++ b/AnoMech/Scenarios/Umad/P2Forsaken/UmadP2ForsakenScenario.cs
@@ -50,6 +50,10 @@ public sealed class UmadP2ForsakenScenario : IScenario
         new UmadP2ForsakenSouthFlex341OldAi(),
     ];
 
+    // NA holds the existing strats; EU is reserved for this branch's new strat (none
+    // yet — its dropdown stays empty and Start is gated off until one is added).
+    public IReadOnlyList<string> StratGroups { get; } = ["NA", "EU"];
+
     private UmadP2ForsakenState state = null!;
     private SimWorld world = null!;
     private SimParty party = null!;
@@ -62,7 +66,7 @@ public sealed class UmadP2ForsakenScenario : IScenario
         world = worldParam;
         party = worldParam.Party;
         state = new UmadP2ForsakenState(party, settingsWindow.Overrides);
-        if (selectedAi is { } idx && idx < AiStrats.Count)
+        if (selectedAi is { } idx && idx >= 0 && idx < AiStrats.Count)
             ((IScenarioAi<UmadP2ForsakenState>)AiStrats[idx]).Run(state, world);
         damage = new DamageSolver(party);
         damage.SetStatuses(DamageType.Magic, StatusId.MagicVulnerabilityUp);

--- a/AnoMech/Scenarios/Umad/P2Forsaken/UmadP2ForsakenScenario.cs
+++ b/AnoMech/Scenarios/Umad/P2Forsaken/UmadP2ForsakenScenario.cs
@@ -35,6 +35,7 @@ public sealed class UmadP2ForsakenScenario : IScenario
         PlayerPosition: new Vector3(100.000f, 0f, 116.000f),
         WeatherId: 79);
     public IReadOnlyList<Waymark> Waymarks { get; } = UmadWaymarks;
+    public IReadOnlyList<WaymarkLayout> WaymarkPresets { get; } = UmadConstants.WaymarkPresets;
     public ushort Bgm => 533;
     
     public IReadOnlyList<Vector3> ColliderRemovalPoints => [new(0, 0, -10)];

--- a/AnoMech/Scenarios/Umad/P2Forsaken/UmadP2ForsakenScenario.cs
+++ b/AnoMech/Scenarios/Umad/P2Forsaken/UmadP2ForsakenScenario.cs
@@ -49,10 +49,13 @@ public sealed class UmadP2ForsakenScenario : IScenario
         new UmadP2ForsakenSouthFlexAi(),
         new UmadP2ForsakenKroxyRinonOldAi(),
         new UmadP2ForsakenSouthFlex341OldAi(),
+        new UmadP2ForsakenP3ZBuddyMeowAi(),
+        new UmadP2ForsakenZP6SouthAdjustAi(),
     ];
 
-    // NA holds the existing strats; EU is reserved for this branch's new strat (none
-    // yet — its dropdown stays empty and Start is gated off until one is added).
+    // NA holds the existing strats; EU holds this branch's new strats — isolated copies
+    // of NA strats over their own forked helpers ("p3Z Buddy Meow" from Kroxy-Rinon 341,
+    // "zP6 South adjust" from South Flex 341) — more to come.
     public IReadOnlyList<string> StratGroups { get; } = ["NA", "EU"];
 
     private UmadP2ForsakenState state = null!;

--- a/AnoMech/Scenarios/Umad/P3BlackHole/UmadP3BlackHoleScenario.cs
+++ b/AnoMech/Scenarios/Umad/P3BlackHole/UmadP3BlackHoleScenario.cs
@@ -26,6 +26,7 @@ public sealed class UmadP3BlackHoleScenario : IScenario
         PlayerPosition: new Vector3(100.000f, 0f, 116.000f),
         WeatherId: 174);
     public IReadOnlyList<Waymark> Waymarks { get; } = UmadWaymarks;
+    public IReadOnlyList<WaymarkLayout> WaymarkPresets { get; } = UmadConstants.WaymarkPresets;
     public ushort Bgm => 533;
 
     public IReadOnlyList<Vector3> ColliderRemovalPoints => [new(0, 0, -10)];

--- a/AnoMech/Scenarios/Umad/P4KefkaSays/UmadP4KefkaSaysScenario.cs
+++ b/AnoMech/Scenarios/Umad/P4KefkaSays/UmadP4KefkaSaysScenario.cs
@@ -24,6 +24,7 @@ public sealed class UmadP4KefkaSaysScenario : IScenario
         PlayerPosition: new Vector3(100.000f, 0f, 116.000f),
         WeatherId: 174);
     public IReadOnlyList<Waymark> Waymarks { get; } = UmadWaymarks;
+    public IReadOnlyList<WaymarkLayout> WaymarkPresets { get; } = UmadConstants.WaymarkPresets;
     public ushort Bgm => 20293;
     
     public IReadOnlyList<Vector3> ColliderRemovalPoints => [new(0, 0, -10)];

--- a/AnoMech/Scenarios/Umad/UmadConstants.cs
+++ b/AnoMech/Scenarios/Umad/UmadConstants.cs
@@ -233,4 +233,23 @@ public static class UmadConstants
         new(WaymarkSlot.Three, new Vector3(  6, 0,   6)),
         new(WaymarkSlot.Four,  new Vector3( -6, 0,   6)),
     ];
+
+    // Named waymark layouts for the UMAD family, surfaced in the main window's
+    // "Waymarks:" dropdown. Default is the 12y "Diamond" layout (UmadWaymarks);
+    // append more entries here to add choices.
+    public static IReadOnlyList<WaymarkLayout> WaymarkPresets { get; } =
+    [
+        new WaymarkLayout("Diamond Waymarks", UmadWaymarks),
+        new WaymarkLayout("DN Zenith Waymarks",
+        [
+            new(WaymarkSlot.A,     new Vector3(    0, 0,   -12)),
+            new(WaymarkSlot.B,     new Vector3(   12, 0,     0)),
+            new(WaymarkSlot.C,     new Vector3(    0, 0,    12)),
+            new(WaymarkSlot.D,     new Vector3(  -12, 0,     0)),
+            new(WaymarkSlot.One,   new Vector3(-8.765f, 0, -8.765f)),
+            new(WaymarkSlot.Two,   new Vector3( 8.628f, 0, -8.765f)),
+            new(WaymarkSlot.Three, new Vector3( 8.628f, 0,  8.628f)),
+            new(WaymarkSlot.Four,  new Vector3(-8.765f, 0,  8.628f)),
+        ]),
+    ];
 }

--- a/AnoMech/Windows/MainWindow.cs
+++ b/AnoMech/Windows/MainWindow.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using System.Reflection;
 using Dalamud.Bindings.ImGui;
@@ -7,6 +8,7 @@ using Dalamud.Interface.Components;
 using Dalamud.Interface.Windowing;
 using AnoMech.Core.Map;
 using AnoMech.Core;
+using AnoMech.Core.Game.Ai;
 using AnoMech.Core.Game.Party;
 using AnoMech.Scenarios;
 
@@ -24,8 +26,19 @@ public unsafe class MainWindow : Window, IDisposable
 
     // Index into the selected scenario's AiStrats; reset to the first strat whenever the
     // selected scenario changes. Passed to RunScenario as selectedAi on a (non-solo) Start.
+    // -1 when a grouped scenario's selected region has no strats (Start is then gated off).
     internal int SelectedStrat => _selectedStrat;
     private int _selectedStrat;
+
+    // The region/group label currently selected in the strat picker, for scenarios that
+    // declare StratGroups. Null until a grouped scenario is drawn (then it snaps to the
+    // first group); stays null for ungrouped scenarios. Filters AiStrats under the buttons.
+    private string? _selectedStratGroup;
+
+    // Remembers the last region the user picked per grouped scenario. On a scenario switch
+    // _selectedStratGroup is restored from here instead of being reset, so coming back to a
+    // scenario keeps its previously selected region rather than snapping to the first.
+    private readonly Dictionary<IScenario, string> _stratGroupMemory = new();
 
     // Index 0 = Auto (null override); indices 1..8 map to (PartyRole)(idx - 1).
     // Labels are the canonical raid role abbreviations: MT/OT tanks, H1/H2 healers
@@ -150,6 +163,8 @@ public unsafe class MainWindow : Window, IDisposable
                 {
                     _selectedScenario = scenario;
                     _selectedStrat = 0;
+                    // Restore the last region picked for this scenario; null self-heals to its first region when drawn.
+                    _selectedStratGroup = _stratGroupMemory.GetValueOrDefault(scenario);
                 }
                 ImGui.PopID();
                 if (selected) ImGui.PopStyleColor();
@@ -180,7 +195,9 @@ public unsafe class MainWindow : Window, IDisposable
 
         var inInn = ZoneSession.IsInInn();
         var busy = ZoneSession.IsPlayerBusy();
-        var canStart = inInn && !busy;
+        var envReady = inInn && !busy;
+        var hasStrat = HasStartableStrat();
+        var canStart = envReady && hasStrat;
         ImGui.BeginDisabled(!canStart);
         if (ImGui.Button("Start")) game.RunScenario(_selectedScenario, _roleOverride, _selectedStrat);
         ImGui.EndDisabled();
@@ -188,7 +205,9 @@ public unsafe class MainWindow : Window, IDisposable
         {
             ImGui.SetTooltip(!inInn
                 ? "Scenarios can only be started from an inn."
-                : "Cannot start while you are busy (cutscene, NPC event, crafting, trading, zoning, etc.).");
+                : busy
+                    ? "Cannot start while you are busy (cutscene, NPC event, crafting, trading, zoning, etc.)."
+                    : "No strat available for this region yet.");
         }
         ImGui.SameLine();
         if (ImGui.Button("Reset")) game.Reset();
@@ -200,10 +219,10 @@ public unsafe class MainWindow : Window, IDisposable
 
         if (_selectedScenario.SupportsSolo)
         {
-            ImGui.BeginDisabled(!canStart);
+            ImGui.BeginDisabled(!envReady);
             if (ImGui.Button("Start Solo")) game.RunScenario(_selectedScenario, _roleOverride, selectedAi: null);
             ImGui.EndDisabled();
-            if (!canStart && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+            if (!envReady && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
             {
                 ImGui.SetTooltip(!inInn
                     ? "Scenarios can only be started from an inn."
@@ -248,10 +267,19 @@ public unsafe class MainWindow : Window, IDisposable
     }
 
     // Only meaningful when a scenario offers more than one strat; hidden otherwise.
+    // When the scenario declares StratGroups, a region-button row is drawn above the
+    // dropdown and the dropdown is filtered to the selected region.
     private void DrawStratSelector()
     {
         if (_selectedScenario is null) return;
         var strats = _selectedScenario.AiStrats;
+        var groups = _selectedScenario.StratGroups;
+        if (groups.Count > 0)
+        {
+            DrawGroupedStratSelector(strats, groups);
+            return;
+        }
+
         if (strats.Count <= 1) return;
         _selectedStrat = Math.Clamp(_selectedStrat, 0, strats.Count - 1);
         var labels = new string[strats.Count];
@@ -260,6 +288,72 @@ public unsafe class MainWindow : Window, IDisposable
         ImGui.SameLine();
         ImGui.SetNextItemWidth(280);
         ImGui.Combo("##strat", ref _selectedStrat, labels, labels.Length);
+    }
+
+    // Region buttons + a region-filtered strat dropdown. _selectedStrat stays an
+    // absolute index into AiStrats (what RunScenario consumes); it is reconciled here
+    // each frame to the selected region, or set to -1 when that region has no strats.
+    private void DrawGroupedStratSelector(IReadOnlyList<IScenarioAi> strats, IReadOnlyList<string> groups)
+    {
+        if (!GroupsContain(groups, _selectedStratGroup))
+            _selectedStratGroup = groups[0];
+
+        ImGui.TextUnformatted("Region:");
+        for (var i = 0; i < groups.Count; i++)
+        {
+            ImGui.SameLine();
+            var group = groups[i];
+            var selected = _selectedStratGroup == group;
+            if (selected) ImGui.PushStyleColor(ImGuiCol.Button, ImGui.GetColorU32(ImGuiCol.ButtonActive));
+            ImGui.PushID($"region{i}");
+            if (ImGui.Button(group))
+            {
+                _selectedStratGroup = group;
+                _stratGroupMemory[_selectedScenario!] = group; // remember across scenario switches
+            }
+            ImGui.PopID();
+            if (selected) ImGui.PopStyleColor();
+        }
+
+        var filtered = new List<int>();
+        for (var i = 0; i < strats.Count; i++)
+            if (strats[i].Group == _selectedStratGroup) filtered.Add(i);
+
+        ImGui.TextUnformatted("Select Strat:");
+        ImGui.SameLine();
+        if (filtered.Count == 0)
+        {
+            _selectedStrat = -1;
+            ImGui.TextDisabled("(no strats for this region yet)");
+            return;
+        }
+
+        if (!filtered.Contains(_selectedStrat)) _selectedStrat = filtered[0];
+        var localIdx = filtered.IndexOf(_selectedStrat);
+        var labels = new string[filtered.Count];
+        for (var i = 0; i < filtered.Count; i++) labels[i] = strats[filtered[i]].Name;
+        ImGui.SetNextItemWidth(280);
+        if (ImGui.Combo("##strat", ref localIdx, labels, labels.Length))
+            _selectedStrat = filtered[localIdx];
+    }
+
+    // True when Start may run a strat: ungrouped scenarios are always fine; grouped
+    // scenarios require the current selection to be a real strat in the active region.
+    private bool HasStartableStrat()
+    {
+        if (_selectedScenario is not { } scenario) return false;
+        if (scenario.StratGroups.Count == 0) return true;
+        var strats = scenario.AiStrats;
+        return _selectedStrat >= 0 && _selectedStrat < strats.Count
+            && strats[_selectedStrat].Group == _selectedStratGroup;
+    }
+
+    private static bool GroupsContain(IReadOnlyList<string> groups, string? group)
+    {
+        if (group is null) return false;
+        for (var i = 0; i < groups.Count; i++)
+            if (groups[i] == group) return true;
+        return false;
     }
 
     private void DrawLocationHint()

--- a/AnoMech/Windows/MainWindow.cs
+++ b/AnoMech/Windows/MainWindow.cs
@@ -8,7 +8,6 @@ using Dalamud.Interface.Components;
 using Dalamud.Interface.Windowing;
 using AnoMech.Core.Map;
 using AnoMech.Core;
-using AnoMech.Core.Game;
 using AnoMech.Core.Game.Ai;
 using AnoMech.Core.Game.Party;
 using AnoMech.Scenarios;

--- a/AnoMech/Windows/MainWindow.cs
+++ b/AnoMech/Windows/MainWindow.cs
@@ -8,6 +8,7 @@ using Dalamud.Interface.Components;
 using Dalamud.Interface.Windowing;
 using AnoMech.Core.Map;
 using AnoMech.Core;
+using AnoMech.Core.Game;
 using AnoMech.Core.Game.Ai;
 using AnoMech.Core.Game.Party;
 using AnoMech.Scenarios;
@@ -29,6 +30,12 @@ public unsafe class MainWindow : Window, IDisposable
     // -1 when a grouped scenario's selected region has no strats (Start is then gated off).
     internal int SelectedStrat => _selectedStrat;
     private int _selectedStrat;
+
+    // Index into the selected scenario's WaymarkPresets; reset to the first preset when the
+    // selected scenario changes. Passed to RunScenario as selectedWaymark on Start. Ignored
+    // by scenarios that declare no presets.
+    internal int SelectedWaymark => _selectedWaymark;
+    private int _selectedWaymark;
 
     // The region/group label currently selected in the strat picker, for scenarios that
     // declare StratGroups. Null until a grouped scenario is drawn (then it snaps to the
@@ -163,6 +170,7 @@ public unsafe class MainWindow : Window, IDisposable
                 {
                     _selectedScenario = scenario;
                     _selectedStrat = 0;
+                    _selectedWaymark = 0;
                     // Restore the last region picked for this scenario; null self-heals to its first region when drawn.
                     _selectedStratGroup = _stratGroupMemory.GetValueOrDefault(scenario);
                 }
@@ -192,6 +200,7 @@ public unsafe class MainWindow : Window, IDisposable
 
         DrawRoleSelector();
         DrawStratSelector();
+        DrawWaymarkSelector();
 
         var inInn = ZoneSession.IsInInn();
         var busy = ZoneSession.IsPlayerBusy();
@@ -199,7 +208,7 @@ public unsafe class MainWindow : Window, IDisposable
         var hasStrat = HasStartableStrat();
         var canStart = envReady && hasStrat;
         ImGui.BeginDisabled(!canStart);
-        if (ImGui.Button("Start")) game.RunScenario(_selectedScenario, _roleOverride, _selectedStrat);
+        if (ImGui.Button("Start")) game.RunScenario(_selectedScenario, _roleOverride, _selectedStrat, _selectedWaymark);
         ImGui.EndDisabled();
         if (!canStart && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
         {
@@ -220,7 +229,7 @@ public unsafe class MainWindow : Window, IDisposable
         if (_selectedScenario.SupportsSolo)
         {
             ImGui.BeginDisabled(!envReady);
-            if (ImGui.Button("Start Solo")) game.RunScenario(_selectedScenario, _roleOverride, selectedAi: null);
+            if (ImGui.Button("Start Solo")) game.RunScenario(_selectedScenario, _roleOverride, selectedAi: null, _selectedWaymark);
             ImGui.EndDisabled();
             if (!envReady && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
             {
@@ -254,6 +263,27 @@ public unsafe class MainWindow : Window, IDisposable
             debugMenu.DrawDebugContent();
         }
 #endif
+    }
+
+    // Drawn below the strat picker for scenarios that declare WaymarkPresets. _selectedWaymark
+    // is the index passed to RunScenario on Start; changing it while a scenario is loaded
+    // re-places the markers immediately (same live-feedback loop as the position readout).
+    private void DrawWaymarkSelector()
+    {
+        if (_selectedScenario is null) return;
+        var presets = _selectedScenario.WaymarkPresets;
+        if (presets.Count == 0) return;
+        if (_selectedWaymark < 0 || _selectedWaymark >= presets.Count) _selectedWaymark = 0;
+
+        var labels = new string[presets.Count];
+        for (var i = 0; i < presets.Count; i++) labels[i] = presets[i].Name;
+
+        ImGui.TextUnformatted("Waymarks:");
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(180);
+        if (ImGui.Combo("##waymarks", ref _selectedWaymark, labels, labels.Length)
+            && plugin.Game.World.Map.IsInInstance)
+            plugin.Game.World.PlaceWaymarks(presets[_selectedWaymark].Markers);
     }
 
     private void DrawRoleSelector()

--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ See: https://github.com/anomek/MyDalamudPlugins
 
 ## Currently implemented:
 - Dancing Mad (Ultimate)
-    - P2 Forsaken 
-      - [South Adjust 341](https://raidplan.io/plan/uq7zdjvuu7uuw8fj)
-      - [Kroxy-Rinon 341 (Center/N Stacks) melee adjust](https://raidplan.io/plan/UATE__aDcw1-bgVv)
+    - P2 Forsaken
+      - NA
+        - [South Adjust 341](https://raidplan.io/plan/uq7zdjvuu7uuw8fj)
+        - [Kroxy-Rinon 341 (Center/N Stacks) melee adjust](https://raidplan.io/plan/UATE__aDcw1-bgVv)
+      - EU
+        - [p3Z Buddy Meow](https://raidplan.io/plan/lZWqxfxvyhF9sp3Z)
+        - [zP6 South adjust](https://raidplan.io/plan/rtc1FcuZFMuyBzP6)
       - you can choose between original positions and ones that use diamond markers
     - P3 Black Hole (Work in Pogress) _kefkabin_
     - P4 Kefka Says _kefkabin_


### PR DESCRIPTION
## What's this

Adds two EU-region strats to UMAD P2 Forsaken:

- **p3Z Buddy Meow** : forked from Kroxy-Rinon 341. new stack tower spots,
  and the cone group takes the right stack spot on first tower.
- **zP6 South adjust** : forked from South Flex 341. new stack tower spots with the
  South-Flex order tweaked (left pair swapped).

Each one is its own isolated copy, so they can do their own thing without
touching the NA strats at all.

## The supporting bits

To actually pick these in-game, this also adds:

- A small **NA/EU region row** above the strat dropdown. NA holds the 4 existing
  strats, EU holds the two new ones. It remembers which region you last picked.
- A **Waymarks dropdown** so you can swap the marker layout. Wired into P2 Forsaken,
  P4 Kefka Says, and P3 Black Hole.

Both are opt-in. scenarios that don't use them look and behave exactly like before.