### PR TITLE
Add Ultimate Predation Scenario

### DIFF
--- a/AnoMech/Core/Game/CharacterFind.cs
+++ b/AnoMech/Core/Game/CharacterFind.cs
@@ -202,6 +202,16 @@ public sealed class CharacterFind<T> where T : IPositioned
         return pool.Count == 0 ? default : pool[Random.Shared.Next(pool.Count)];
     }
 
+    public IReadOnlyList<T> FarestN(Vector3 from, int count)
+    {
+        var fromV2 = new Vector2(from.X, from.Z);
+
+        return source()
+            .OrderByDescending(x => Vector2.DistanceSquared(new Vector2(x.Position.X, x.Position.Z), fromV2))
+            .Take(count)
+            .ToList();
+    }
+
     // One member chosen uniformly at random from the live set. Null when empty.
     public T? RandomMember()
     {

--- a/AnoMech/Core/Game/Game.cs
+++ b/AnoMech/Core/Game/Game.cs
@@ -14,6 +14,7 @@ using AnoMech.Scenarios.Top.P6WaveCannon2;
 using AnoMech.Scenarios.Umad.P2Forsaken;
 using AnoMech.Scenarios.Umad.P3BlackHole;
 using AnoMech.Scenarios.Umad.P4KefkaSays;
+using AnoMech.Scenarios.Uwu.UltimatePredation;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using FFXIVClientStructs.FFXIV.Client.Game;
@@ -68,6 +69,7 @@ public sealed class Game : IDisposable
             new TopP5SigmaScenario(),
             new TopP5OmegaScenario(),
             new TopP6WaveCannon2Scenario(),
+            new UltimatePredationScenario()
         };
     }
 

--- a/AnoMech/Core/Game/Placement.cs
+++ b/AnoMech/Core/Game/Placement.cs
@@ -11,6 +11,9 @@ public readonly record struct Placement(Vector3 Position, float Rotation)
     public Placement MoveForward(float distance) =>
         this with { Position = Position + new Vector3(MathF.Sin(Rotation), 0f, MathF.Cos(Rotation)) * distance };
 
+    public Placement MoveRight(float distance) =>
+        new(Position + (new Vector3(-MathF.Cos(Rotation), 0, MathF.Sin(Rotation)) * distance), Rotation);
+
     // Rotates Position around world origin in the XZ plane by `angle` radians
     // and advances Rotation by the same amount.
     public Placement RotateAroundOrigin(float angle)

--- a/AnoMech/Core/SimObjects/SimCast.cs
+++ b/AnoMech/Core/SimObjects/SimCast.cs
@@ -37,14 +37,15 @@ public sealed unsafe class SimCast : ISimObject
     private float animationLock;
     private float remainingAnimationLock;
 
-    public bool IsCasting => casting;
+    public bool IsCasting => parent.BattleCharaPtr != null && parent.BattleCharaPtr->CastInfo.IsCasting;
+
     public uint ActionId { get; private set; }
     public float Progress => total <= 0f ? 0f : Math.Clamp(elapsed / total, 0f, 1f);
 
     // True while the cast bar is up or the release animation is still playing. A
     // following boss roots itself while busy so the action animation finishes in
     // place instead of sliding.
-    public bool IsBusy => casting || remainingAnimationLock > 0f;
+    public bool IsBusy => IsCasting || remainingAnimationLock > 0f;
 
     // SimCast is a persistent subsystem of its caster: the owning SimEnemy holds it
     // as a direct field and ticks/despawns it explicitly, never reaping it by
@@ -116,8 +117,7 @@ public sealed unsafe class SimCast : ISimObject
         if (castTimeValue <= 0)
         {
             FaceTarget(chara);
-            remainingAnimationLock = animationLock;
-            FireActionEffect(chara, actionId, ActionType.Action, targetLocation, targetId, animationVariation, animationLock);
+            FireActionEffect(chara, actionId, ActionType.Action, animationLock, targetLocation, targetId, animationVariation);
             ResetCastState();
         }
         
@@ -209,6 +209,8 @@ public sealed unsafe class SimCast : ISimObject
             &targetEffects,
             &actionTarget
             );
+
+        remainingAnimationLock = animationLock;
     }
 
     public void Tick(float deltaSeconds)
@@ -250,8 +252,7 @@ public sealed unsafe class SimCast : ISimObject
             if (fire)
             {
                 FaceTarget(chara);
-                remainingAnimationLock = animationLock;
-                FireActionEffect(chara, ActionId, ActionType.Action, targetLocation, targetId, animationVariation, animationLock);
+                FireActionEffect(chara, ActionId, ActionType.Action, animationLock, targetLocation, targetId, animationVariation);
                 ResetCastState();
             }
         }
@@ -310,7 +311,7 @@ public sealed unsafe class SimCast : ISimObject
     // deliver to. When deliverTo is null, NumTargets=0 (used for self-targeted
     // casts and cast releases without an entity target) — the release animation
     // still plays.
-    private void FireActionEffect(BattleChara* chara, uint actionId, ActionType actionType, Vector3? localTargetLocation = null, GameObjectId? deliverTo = null, byte animationVariation = 0, float animationLock = 0f)
+    private void FireActionEffect(BattleChara* chara, uint actionId, ActionType actionType, float animationLock, Vector3? localTargetLocation = null, GameObjectId? deliverTo = null, byte animationVariation = 0)
     {
         if (deliverTo is { } id)
         {

--- a/AnoMech/Core/SimObjects/SimCharacter.cs
+++ b/AnoMech/Core/SimObjects/SimCharacter.cs
@@ -168,6 +168,13 @@ public abstract unsafe class SimCharacter(Coordinates coordinates) : ISimObject,
         return s;
     }
 
+    public SimStatus AddStatusParam(ushort statusId, int param, float duration = 0f)
+    {
+        var s = new SimStatus(this, statusId, duration, (ushort)param);
+        statusList.Add(s);
+        return s;
+    }
+
     public void RemoveStatus(ushort statusId)
     {
         FindStatus(statusId)?.Despawn();

--- a/AnoMech/Core/SimObjects/SimEnemy.cs
+++ b/AnoMech/Core/SimObjects/SimEnemy.cs
@@ -257,6 +257,30 @@ public sealed unsafe class SimEnemy : SimNpc
         manualInEnemyList = inEnemyList;
     }
 
+    /// <summary>
+    /// Sets the target of this <see cref="SimEnemy"/>.
+    /// </summary>
+    /// <remarks>For now, this is purely visual and does not contain any logic relating to auto-attacks or similar.</remarks>
+    /// <param name="target">The <see cref="SimCharacter.GameObjectId"/> will be retrieved and used as the TargetId. If <see langword="null"/>, then the target is cleared.</param>
+    /// <param name="follow">If <paramref name="target"/> is valid, this will determine if the <see cref="SimEnemy"/> should now follow <paramref name="target"/> or not.</param>
+    /// <param name="speed">If <paramref name="target"/> is valid and <paramref name="follow"/> is <see langword="true"/>, this will be the speed that the <see cref="SimEnemy"/> will follow the <paramref name="target"/></param>
+    public void SetTarget(SimCharacter? target, bool follow = true, float speed = 6f)
+    {
+        if (target == null)
+        {
+            BattleCharaPtr->TargetId = 0xE0000000;
+        }
+        else
+        {
+            BattleCharaPtr->TargetId = target.GameObjectId;
+
+            if (follow)
+            {
+                Follow(target);
+            }
+        }
+    }
+
     public void SetVisible(bool visible) => desiredVisible = visible;
 
     public void Follow(SimCharacter? target = null, float speed = 6f) => Movement.Follow(target, speed);

--- a/AnoMech/Pointers/TimelineContainerPointers.cs
+++ b/AnoMech/Pointers/TimelineContainerPointers.cs
@@ -8,7 +8,11 @@ internal unsafe class TimelineContainerPointers
     [Signature("E8 ?? ?? ?? ?? 8B D5 48 8D 8B", UseFlags = SignatureUseFlags.Pointer, ScanType = ScanType.Text)]
     public static SetModelStateDelegate SetModelState { get; private set; } = null!;
 
+    [Signature("48 89 5C 24 ?? 57 48 83 EC 20 8B FA 4C 8B", UseFlags = SignatureUseFlags.Pointer, ScanType = ScanType.Text)]
+    public static SetAnimationStateDelegate SetAnimationState { get; private set; } = null!;
+
     public delegate void SetModelStateDelegate(TimelineContainer* self, uint modelStateId);
+    public delegate void SetAnimationStateDelegate(TimelineContainer* thisPtr, int a2, int a3);
 
     public static void Initialize()
     {

--- a/AnoMech/Scenarios/Rng.cs
+++ b/AnoMech/Scenarios/Rng.cs
@@ -54,6 +54,18 @@ public class Rng
         return values.Shuffle().ToList();
     }
 
+    /// <summary>
+    /// Re-orders <paramref name="array"/> and returns a copy starting from a random index.
+    /// </summary>
+    public T[] RandomStart<T>(T[] array)
+    {
+        var start = rng.Next(array.Length);
+
+        return array.Skip(start)
+            .Concat(array.Take(start))
+            .ToArray();
+    }
+
     public PartyRole NextSupportRole()
     {
         return (PartyRole)rng.Next(4);

--- a/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationAi.cs
+++ b/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationAi.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using AnoMech.Core.Game;
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.SimObjects;
+using static AnoMech.Scenarios.Uwu.UwuConstants;
+
+namespace AnoMech.Scenarios.Uwu.UltimatePredation;
+
+public class UltimatePredationAi : IScenarioAi<UltimatePredationState>
+{
+    public string Name => "NAUR";
+
+    private UltimatePredationState state = null!;
+
+    public void Run(UltimatePredationState state, SimWorld world)
+    {
+        this.state = state;
+
+        var ai = new AiManager(world);
+        var safeCardinal = GetSafeCardinal(state);
+
+#if DEBUG
+        Plugin.Log.Debug($"[UltimatePredationAi] safeCardinal = {safeCardinal.Position2}");
+#endif
+
+        var safeFirstSet = GetSafeForFirstSet(state, safeCardinal);
+        var safeSecondSet = GetSafeForSecondSet(state, safeCardinal);
+
+        ai.Move(15f, () => AiMove.All(safeCardinal.Position2), jitter: 0.25f);
+        ai.Move(19f, () => AiMove.All(safeFirstSet.Position2), jitter: 0.125f);
+        ai.Move(21f, () => AiMove.All(safeSecondSet.Position2), jitter: 0);
+        ai.Move(26f, PostDodges, jitter: 0.25f);
+        ai.Move(37.5f, EruptionBaits1, jitter: 0.25f);
+        ai.Move(39.25f, EruptionBaits2, jitter: 0.25f);
+        ai.Move(41.45f, EruptionBaits3, jitter: 0.25f);
+        ai.Move(43.25f, EruptionBaits4, jitter: 0.25f);
+        ai.Move(45.35f, () => AiMove.All(new(0, -8.5f)), jitter: 0.25f);
+        ai.Move(54f, () => AiMove.All(new(0, -18)), jitter: 0.25f);
+        ai.Move(55.75f, UltimaLandslideDodge, jitter: 0.125f);
+        ai.Move(58f, () => AiMove.All(new(0, -18)), jitter: 0.25f);
+        ai.Move(60f, PartySplit, jitter: 0.25f);
+        ai.Move(73.5f, PartySplitFeatherRain, jitter: 0.5f);
+        ai.Move(77f, PartySplit, jitter: 0.25f);
+    }
+
+    private Placement GetSafeCardinal(UltimatePredationState state)
+    {
+        var cardinals = new List<SafePosition>
+        {
+            new(new(0, 0, -18), Geometry.LookAtCenterRotation[DirectionEnum.N]),
+            new(new(0, 0, 18), Geometry.LookAtCenterRotation[DirectionEnum.S]),
+            new(new(-18, 0, 0), Geometry.LookAtCenterRotation[DirectionEnum.W]),
+            new(new(18, 0, 0), Geometry.LookAtCenterRotation[DirectionEnum.E]),
+        };
+
+        var finder = new CharacterFind<SafePosition>(cardinals);
+
+        var unsafeGaruda = finder.InsideCircle(state.GarudaPlacement.Position, Geometry.WickedTornadoOuterRadius);
+        var unsafeTitan = finder.InsideCircle(state.TitanPlacement.Position, 10); // Arbitrary value, just to be sure we're not next to Titan
+
+        cardinals.RemoveAll(x => unsafeGaruda.Contains(x) || unsafeTitan.Contains(x));
+        return state.Rng.NextObj(cardinals.ToArray()).Placement();
+    }
+
+    private Placement GetSafeForFirstSet(UltimatePredationState state, Placement safeCardinal)
+    {
+        var left = GetSafeInSide(safeCardinal, 4, true, DeleteUnsafeFirstSet);
+        var right = GetSafeInSide(safeCardinal, 4, false, DeleteUnsafeFirstSet);
+
+        SafePosition position;
+
+        if (left != null && right != null)
+        {
+            position = state.Rng.NextBool() ? left : right;
+        }
+        else if (left != null && right == null)
+        {
+            position = left;
+        }
+        else if (left == null && right != null)
+        {
+            position = right;
+        }
+        else
+        {
+            throw new Exception("[UltimatePredationAi.GetSafeForFirstSet] Was not able to find a safe position.");
+        }
+
+        return position.Placement();
+    }
+
+    private Placement GetSafeForSecondSet(UltimatePredationState state, Placement safeCardinal)
+    {
+        var left = GetSafeInSide(safeCardinal, 6, true, DeleteUnsafeSecondSet);
+        var right = GetSafeInSide(safeCardinal, 6, false, DeleteUnsafeSecondSet);
+
+        SafePosition position;
+
+        if (left != null && right != null)
+        {
+            position = state.Rng.NextBool() ? left : right;
+        }
+        else if (left != null && right == null)
+        {
+            position = left;
+        }
+        else if (left == null && right != null)
+        {
+            position = right;
+        }
+        else
+        {
+            throw new Exception("[UltimatePredationAi.GetSafeForSecondSet] Was not able to find a safe position.");
+        }
+
+        return position.Placement();
+    }
+
+    private SafePosition? GetSafeInSide(Placement placement, float finalOffset, bool negative, Action<List<SafePosition>> deleteUnsafe)
+    {
+        const int Steps = 10;
+        var stepDistance = finalOffset / Steps;
+
+        if (negative)
+        {
+            stepDistance *= -1;
+        }
+
+        var positions = Enumerable.Range(1, Steps + 1)
+            .Select(x => SafePosition.FromPlacement(placement.MoveRight(x * stepDistance)))
+            .ToList();
+
+        deleteUnsafe(positions);
+
+        if (positions.Count == 0)
+        {
+            return null;
+        }
+
+        var index = int.Clamp(positions.Count / 2, 0, positions.Count - 1);
+
+#if DEBUG
+        var str = string.Join('\n', positions);
+
+        Plugin.Log.Debug($"[UltimatePredationAi.GetSafeInSide]\n" +
+            $"{str}\n" +
+            $"Chosen: {positions[index]} (Index {index})");
+#endif
+
+        return positions[index];
+    }
+
+    private void DeleteUnsafeFirstSet(List<SafePosition> list)
+    {
+        var finder = new CharacterFind<SafePosition>(list);
+
+        var unsafeIfrit = finder.InsideActionAoe(ActionId.CrimsonCyclone, state.IfritPlacement);
+
+        var unsafeLandslides = new List<IReadOnlyList<SafePosition>>();
+
+        foreach (var rotation in Geometry.TitanLandslideOffsets)
+        {
+            var landslide = finder.InsideActionAoe(ActionId.LandslideLine, new(state.TitanPlacement.Position, state.TitanPlacement.Rotation + rotation));
+            unsafeLandslides.Add(landslide);
+        }
+
+        var unsafeTitan = unsafeLandslides.SelectMany(x => x);
+
+        list.RemoveAll(x => unsafeIfrit.Contains(x) || unsafeTitan.Contains(x));
+    }
+
+    private void DeleteUnsafeSecondSet(List<SafePosition> list)
+    {
+        var finder = new CharacterFind<SafePosition>(list);
+
+        var unsafeUltima = finder.InsideCircle(state.UltimaPlacement.Position, 10); // ActionId.CeruleumVent has a 8 EffectRange, but for safety we do 10 here
+
+        var unsafeIfrit = new List<IReadOnlyList<SafePosition>>
+            {
+                finder.InsideActionAoe(ActionId.CrimsonCycloneAwaken, Geometry.CrimsonCycloneAwakenPlacements[0]),
+                finder.InsideActionAoe(ActionId.CrimsonCycloneAwaken, Geometry.CrimsonCycloneAwakenPlacements[1])
+            }.SelectMany(x => x);
+
+        var unsafeLandslides = new List<IReadOnlyList<SafePosition>>();
+
+        foreach (var rotation in Geometry.TitanLandslideAwakenOffsets)
+        {
+            var landslide = finder.InsideActionAoe(ActionId.LandslideAwaken, new(state.TitanPlacement.Position, state.TitanPlacement.Rotation + rotation));
+            unsafeLandslides.Add(landslide);
+        }
+
+        var unsafeTitan = unsafeLandslides.SelectMany(x => x);
+
+        list.RemoveAll(x => unsafeUltima.Contains(x) || unsafeIfrit.Contains(x) || unsafeTitan.Contains(x));
+    }
+
+    private IAiMove PostDodges()
+    {
+        return AiMove.Create(
+            new(-1.5f, -10),  // MT
+            new(0, -8), // OT
+            new(0, -8),   // H1
+            new(0, -8),  // H2
+            new(0, -8),   // M1
+            new(0, -8), // M2
+            new(0, 8),  // R1
+            new(0, 8) // R2
+            ).NaturalOrder();
+    }
+
+    private IAiMove EruptionBaits1()
+    {
+        return AiMove.Create(
+            null, null, null, null, null, null,
+            new(-4, 15),  // R1
+            new(4, 15) // R2
+            ).NaturalOrder();
+    }
+
+    private IAiMove EruptionBaits2()
+    {
+        return AiMove.Create(
+            null, null, null, null, null, null,
+            new(-10.5f, 8.5f),  // R1
+            new(10.5f, 8.5f) // R2
+            ).NaturalOrder();
+    }
+
+    private IAiMove EruptionBaits3()
+    {
+        return AiMove.Create(
+            null, null, null, null, null, null,
+            new(-15, -1),  // R1
+            new(15, -1) // R2
+            ).NaturalOrder();
+    }
+
+    private IAiMove EruptionBaits4()
+    {
+        return AiMove.Create(
+            null, null, null, null, null, null,
+            new(-13, -8.5f),  // R1
+            new(13, -8.5f) // R2
+            ).NaturalOrder();
+    }
+
+    private IAiMove UltimaLandslideDodge()
+    {
+        var positions = new Vector2[]
+        {
+            new(-4.5f, -17.5f),
+            new(4.5f, -17.5f)
+        };
+
+        var titanPosition2 = new Vector2(state.ScenarioObjects.Titan!.Position.X, state.ScenarioObjects.Titan.Position.Z);
+
+        var closest = positions
+            .OrderBy(x => Vector2.DistanceSquared(x, titanPosition2))
+            .First();
+
+        return AiMove.All(closest);
+    }
+
+    private IAiMove PartySplit()
+    {
+        return AiMove.Create(
+            new(5, -12f), // MT
+            new(-5, -14f), // OT
+            new(-5, -14f),   // H1
+            new(-5, -14f),  // H2
+            new(-5, -14f),   // M1
+            new(-5, -14f), // M2
+            new(-5, -14f),  // R1
+            new(-5, -14f) // R2
+            ).NaturalOrder();
+    }
+
+    private IAiMove PartySplitFeatherRain()
+    {
+        return AiMove.Create(
+            new(5, -7.5f), // MT
+            new(-5, -7.5f), // OT
+            new(-5, -7.5f),   // H1
+            new(-5, -7.5f),  // H2
+            new(-5, -7.5f),   // M1
+            new(-5, -7.5f), // M2
+            new(-5, -7.5f),  // R1
+            new(-5, -7.5f) // R2
+            ).NaturalOrder();
+    }
+
+    private class SafePosition(Vector3 Position, float Rotation) : IPositioned
+    {
+        public Vector3 Position { get; } = Position;
+
+        public float Rotation { get; } = Rotation;
+
+        public static SafePosition FromPlacement(Placement placement)
+        {
+            return new(placement.Position, placement.Rotation);
+        }
+
+        public override string ToString()
+        {
+            return $"Position = {Position}; Rotation = {Rotation}";
+        }
+    }
+}

--- a/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationScenario.cs
+++ b/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationScenario.cs
@@ -1,0 +1,1333 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using AnoMech.Core.Game;
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.Game.Party;
+using AnoMech.Core.Map;
+using AnoMech.Core.SimObjects;
+using AnoMech.Pointers;
+using Dalamud.Game.Text;
+using Dalamud.Game.Text.SeStringHandling;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.Network;
+using static AnoMech.Scenarios.Uwu.UwuConstants;
+
+namespace AnoMech.Scenarios.Uwu.UltimatePredation;
+
+public unsafe class UltimatePredationScenario : IScenario
+{
+    public string Name => "Ultimate Predation";
+
+    public TargetInstance TargetInstance => new(
+        TerritoryId: 777,
+        Origin: new Vector3(100, 0, 100),
+        PlayerPosition: new Vector3(100, 0, 116),
+        WeatherId: 95
+        );
+
+    public IReadOnlyList<Waymark> Waymarks => NaurWaymarks;
+    public ushort Bgm => 547;
+    public byte Level => UwuConstants.Level;
+    public ushort ItemLevel => UwuConstants.ItemLevel;
+    public IReadOnlyList<IScenarioAi> AiStrats => [new UltimatePredationAi()];
+    public void DrawSettings() => settingsWindow.Draw();
+
+    private readonly UltimatePredationSettingsWindow settingsWindow = new();
+
+    private SimWorld world = null!;
+    private SimParty party = null!;
+
+    private UltimatePredationState state = null!;
+
+    private SimEnemy? ultima;
+    private SimEnemy? garuda;
+    private SimEnemy? ifrit;
+
+    private SimEnemy?[] dummies = new SimEnemy?[13];
+
+    private List<Vector3> featherRainPositions = new();
+
+    private SimEnemy? titan => state.ScenarioObjects.Titan;
+
+    public void Run(SimWorld world, int? selectedAi)
+    {
+        this.world = world;
+        party = world.Party;
+
+        state = new(settingsWindow.Overrides);
+
+        if (selectedAi is { } idx && idx < AiStrats.Count)
+            ((IScenarioAi<UltimatePredationState>)AiStrats[idx]).Run(state, world);
+
+        Init();
+        Arena();
+        Ultima();
+        UltimaPost();
+        Garuda();
+        GarudaPost();
+        Ifrit();
+        IfritPost();
+        Titan();
+        TitanPost();
+    }
+
+    private void Init()
+    {
+        world.Events.Add(0, () =>
+        {
+            ultima = world.SpawnEnemy(
+                new EnemySpawnConfig(
+                    BNpcBaseId: BNpcBaseId.UltimaWeapon,
+                    NameId: BNpcNameId.UltimaWeapon,
+                    Level: 70,
+                    Targetable: true,
+                    EnemyList: EnemyListMode.Always,
+                    IsVisible: true,
+                    Placement: new Placement(
+                        new Vector3(0, 0, -10),
+                        0),
+                    InitialModeAttributeFlags: 0x11)
+                );
+
+            garuda = world.SpawnEnemy(
+                new EnemySpawnConfig(
+                    BNpcBaseId: BNpcBaseId.Garuda,
+                    NameId: BNpcNameId.Garuda,
+                    Level: 70,
+                    Targetable: false,
+                    EnemyList: EnemyListMode.Never,
+                    IsVisible: false,
+                    Placement: new Placement(
+                        new Vector3(0, 0, 0),
+                        0))
+                );
+
+            garuda?.AddStatusParam(StatusId.Woken, 0);
+
+            ifrit = world.SpawnEnemy(
+                new EnemySpawnConfig(
+                    BNpcBaseId: BNpcBaseId.Ifrit,
+                    NameId: BNpcNameId.Ifrit,
+                    Level: 70,
+                    Targetable: false,
+                    EnemyList: EnemyListMode.Never,
+                    IsVisible: false,
+                    Placement: new Placement(
+                        new Vector3(0, 0, 0),
+                        0))
+                );
+
+            ifrit?.AddStatusParam(StatusId.Woken, 0);
+
+            var titan = world.SpawnEnemy(
+                new EnemySpawnConfig(
+                    BNpcBaseId: BNpcBaseId.Titan,
+                    NameId: BNpcNameId.Titan,
+                    Level: 70,
+                    Targetable: false,
+                    EnemyList: EnemyListMode.Never,
+                    IsVisible: false,
+                    Placement: new Placement(
+                        new Vector3(0, 0, 0),
+                        0))
+            );
+
+            titan?.AddStatusParam(StatusId.Woken, 0);
+
+            Awaken(ultima!, true);
+            Awaken(garuda!, false);
+            Awaken(ifrit!, false);
+            Awaken(titan!, false);
+
+            state.ScenarioObjects.Titan = titan;
+
+            for (int i = 0; i < dummies.Length; i++)
+            {
+                dummies[i] = world.SpawnEnemy(
+                new EnemySpawnConfig(
+                    BNpcBaseId: BNpcBaseId.Dummy,
+                    NameId: BNpcNameId.Dummy,
+                    Level: 70,
+                    Targetable: false,
+                    EnemyList: EnemyListMode.Never,
+                    IsVisible: true,
+                    Placement: new Placement(
+                        new Vector3(0, 0, 0),
+                        0)
+                    )
+                );
+            }
+        });
+    }
+
+    private void Arena()
+    {
+        world.EnforceArenaBoundary(Geometry.ArenaRadius);
+
+        world.Events.Add(0, () =>
+        {
+            var config = new EventObjectSpawnConfig
+            {
+                EObjId = 2007457,
+                Placement = new(new(0.16f, 0, 1.4434f), 0),
+                ObjectIndex = 1,
+                TargetableStatus = 5,
+                EntityId = 0x4000829C,
+                LayoutId = 7538913,
+                GimmickId = 7538258,
+                TimelineState = 1
+            };
+
+            world.SpawnEventObject(config);
+        });
+
+        world.Events.Add(1, () => UwuUtils.UpdateArena(1));
+
+        world.Events.Add(71.57f, () => UwuUtils.UpdateArena(2));
+    }
+
+    private void Ultima()
+    {
+        world.Events.Add(2.50f, () => ultima?.NativeCast(
+            ActionId.UltimatePredation,
+            ActionType.Action,
+            0f,
+            2.7f,
+            false,
+            targetId: ultima.GameObjectId
+            ));
+
+        world.Events.Add(5.45f, () => ultima?.NativeActionEffect(
+            ActionId.UltimatePredation,
+            4.5f,
+            (ushort)ActionId.UltimatePredation,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: ultima.GameObjectId
+            ));
+
+        world.Events.Add(10.05f, () =>
+        {
+            ultima?.SetTargetable(false);
+            ultima?.PlayActionTimeline(ActionTimelineId.WarpStart);
+        });
+
+        world.Events.Add(12.03f, () => ultima?.SetPosition(state.UltimaPlacement));
+
+        world.Events.Add(12.28f, () => ultima?.PlayActionTimeline(ActionTimelineId.WarpEnd));
+
+        IReadOnlyList<SimCharacter> ceruleumVentSnapshot = null!;
+        world.Events.Add(22.28f, () =>
+        {
+            ultima?.NativeActionEffect(
+                ActionId.CeruleumVent,
+                2.1f,
+                (ushort)ActionId.CeruleumVent,
+                0,
+                ActionType.Action,
+                0,
+                animationTargetId: ultima.GameObjectId
+                );
+
+            ceruleumVentSnapshot = party.Find.InsideActionAoe(ActionId.CeruleumVent, ultima!.Placement());
+        });
+
+        world.Events.Add(22.94f, () =>
+        {
+            foreach (var character in ceruleumVentSnapshot)
+            {
+                character.Die("Ceruleum Vent");
+            }
+        });
+
+        world.Events.Add(25.50f, () => ultima?.PlayActionTimeline(ActionTimelineId.WarpStart));
+    }
+
+    private void UltimaPost()
+    {
+        var mt = party.Get(PartyRole.MainTank);
+        var ot = party.Get(PartyRole.OffTank);
+
+        world.Events.Add(27.45f, () => ultima?.SetPosition(
+             new Placement(
+                 new Vector3(0f, 0f, 0f),
+                 0
+             )));
+
+        world.Events.Add(27.70f, () => ultima?.PlayActionTimeline(ActionTimelineId.WarpEnd));
+
+        world.Events.Add(29.77f, () =>
+        {
+            ultima?.SetTargetable(true);
+            ultima?.SetTarget(mt);
+        });
+
+        world.Events.Add(32.92f, () => ultima?.NativeCast(
+            ActionId.PostUltimatePredation2,
+            ActionType.Action,
+            0f,
+            1.7f,
+            false,
+            targetId: ultima.GameObjectId
+            ));
+
+        world.Events.Add(34.77f, () => ultima?.NativeActionEffect(
+            ActionId.PostUltimatePredation2,
+            2.1f,
+            (ushort)ActionId.PostUltimatePredation2,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: ultima.GameObjectId
+            ));
+
+        world.Events.Add(43.94f, () => ultima?.NativeCast(
+            ActionId.PostUltimatePredation3,
+            ActionType.Action,
+            0f,
+            1.7f,
+            false,
+            targetId: ultima.GameObjectId
+            ));
+
+        world.Events.Add(45.90f, () => ultima?.NativeActionEffect(
+            ActionId.PostUltimatePredation3,
+            2.1f,
+            (ushort)ActionId.PostUltimatePredation3,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: ultima.GameObjectId
+            ));
+
+        world.Events.Add(49.05f, () => ultima?.NativeCast(
+            ActionId.RadiantPlumeUltima,
+            ActionType.Action,
+            0f,
+            2.9f,
+            false,
+            targetId: ultima.GameObjectId
+            ));
+
+        for (int i = 0; i < Geometry.UltimaRadiantPlumePositions.Length; i++)
+        {
+            RadiantPlume(Geometry.UltimaRadiantPlumePositions[i], 5 + i);
+        }
+
+        world.Events.Add(52.20f, () => ultima?.NativeActionEffect(
+            ActionId.RadiantPlumeUltima,
+            2.1f,
+            (ushort)ActionId.RadiantPlumeUltima,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: ultima.GameObjectId
+            ));
+
+        world.Events.Add(55.09f, () =>
+        {
+            var bait = party.GetRandom();
+            ultima?.Face(bait);
+
+            ultima?.NativeCast(
+                ActionId.LandslideUltima,
+                ActionType.Action,
+                0f,
+                1.9f,
+                false,
+                targetId: ultima.GameObjectId
+                );
+        });
+
+        Landslide(55.09f, 57.25f, 5, LandslideType.Ultima);
+
+        world.Events.Add(57.25f, () => ultima?.NativeActionEffect(
+            ActionId.LandslideUltima,
+            2.1f,
+            (ushort)ActionId.LandslideUltima,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: ultima.GameObjectId
+            ));
+
+        world.Events.Add(60.37f, () => ultima?.NativeCast(
+            ActionId.PostUltimatePredation1,
+            ActionType.Action,
+            0f,
+            1.7f,
+            false,
+            targetId: ultima.GameObjectId
+            ));
+
+        world.Events.Add(62.29f, () => ultima?.NativeActionEffect(
+            ActionId.PostUltimatePredation1,
+            2.1f,
+            (ushort)ActionId.PostUltimatePredation1,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: ultima.GameObjectId
+            ));
+
+        world.Events.Add(64.38f, () => ultima?.NativeActionEffect(
+            ActionId.ViscousAetheroplasmUltima,
+            2.1f,
+            (ushort)ActionId.ViscousAetheroplasmUltima,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: mt!.GameObjectId
+            ));
+
+        world.Events.Add(65.34f, () => mt!.AddStatus(1532, 10));
+
+        world.Events.Add(69, () =>
+        {
+            // TODO: Use a proper Enmity system for this
+            Plugin.ChatGui.Print(new XivChatEntry
+            {
+                Type = XivChatType.SystemMessage,
+                Message = new SeStringBuilder().AddText($"[AnoMech] {Name}: Assuming Tank Swap").Build(),
+            });
+
+            ultima?.SetTarget(ot);
+        });
+
+        world.Events.Add(73.64f, () => ultima?.NativeCast(
+            ActionId.HomingLasers,
+            ActionType.Action,
+            0f,
+            2.7f,
+            false,
+            targetId: mt!.GameObjectId
+            ));
+
+        // Viscous Aetheroplasm is handled by dummies[7]
+        IReadOnlyList<SimCharacter> viscousAetheroplasm = null!;
+        world.Events.Add(75.57f, () =>
+        {
+            dummies[7]?.NativeActionEffect(
+                ActionId.ViscousAetheroplasmEffect,
+                1.1f,
+                (ushort)ActionId.ViscousAetheroplasmEffect,
+                0,
+                ActionType.Action,
+                0,
+                animationTargetId: mt!.GameObjectId
+                );
+
+            viscousAetheroplasm = party.Find.InsideActionAoe(ActionId.ViscousAetheroplasmEffect, new(mt!.Position, 0));
+        });
+
+        // TODO: Should do an invuln check
+        world.Events.Add(76.07f, () => ResolveSnapshotTankbuster(viscousAetheroplasm, "Viscous Aetheroplasm"));
+
+        IReadOnlyList<SimCharacter> homingLasersSnapshot = null!;
+        world.Events.Add(76.34f, () => homingLasersSnapshot = party.Find.InsideActionAoe(ActionId.HomingLasers, new(mt!.Position, 0)));
+
+        world.Events.Add(76.76f, () => ultima?.NativeActionEffect(
+            ActionId.HomingLasers,
+            2.1f,
+            (ushort)ActionId.HomingLasers,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: mt!.GameObjectId
+            ));
+
+        world.Events.Add(77.34f, () =>
+        {
+            // TODO: Use a proper Enmity system for this
+            Plugin.ChatGui.Print(new XivChatEntry
+            {
+                Type = XivChatType.SystemMessage,
+                Message = new SeStringBuilder().AddText($"[AnoMech] {Name}: Assuming Tank Swap").Build(),
+            });
+
+            ultima?.SetTarget(mt);
+        });
+
+        // TODO: Should do an invuln check
+        world.Events.Add(79.22f, () => ResolveSnapshotTankbuster(homingLasersSnapshot, "Homing Lasers"));
+
+        world.Events.Add(80.97f, () => ultima?.NativeCast(
+            ActionId.UltimateAnnihilation,
+            ActionType.Action,
+            0f,
+            2.7f,
+            false,
+            targetId: ultima.GameObjectId
+            ));
+
+        world.Events.Add(83.81f, () => ultima?.NativeActionEffect(
+            ActionId.UltimateAnnihilation,
+            4.5f,
+            (ushort)ActionId.UltimateAnnihilation,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: ultima.GameObjectId
+            ));
+
+        world.Events.Add(88.41f, () =>
+        {
+            ultima?.SetTargetable(false);
+            ultima?.PlayActionTimeline(ActionTimelineId.WarpStart);
+        });
+    }
+
+    private void Garuda()
+    {
+        world.Events.Add(12.03f, () => garuda?.SetPosition(state.GarudaPlacement));
+
+        world.Events.Add(12.28f, () =>
+        {
+            garuda?.SetVisible(true);
+            garuda?.PlayActionTimeline(ActionTimelineId.WarpEnd);
+        });
+
+        world.Events.Add(17.52f, () => garuda?.NativeCast(
+            ActionId.WickedWheelAwaken,
+            ActionType.Action,
+            0f,
+            2.7f,
+            false,
+            targetId: garuda.GameObjectId
+            ));
+
+        IReadOnlyList<SimCharacter> wickedWheelSnapshot = null!;
+        world.Events.Add(20.22f, () => wickedWheelSnapshot = party.Find.InsideActionAoe(ActionId.WickedWheelAwaken, garuda!.Placement()));
+
+        world.Events.Add(20.43f, () => garuda?.NativeActionEffect(
+            ActionId.WickedWheelAwaken,
+            2.8f,
+            (ushort)ActionId.WickedWheelAwaken,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: garuda.GameObjectId
+            ));
+
+        world.Events.Add(21.53f, () => ResolveSnapshot(wickedWheelSnapshot, "Wicked Wheel"));
+
+        // Wicked Tornado is handled by dummies[2]
+        world.Events.Add(22.28f, () => dummies[2]?.SetPosition(garuda!.Placement()));
+
+        IReadOnlyList<SimCharacter> wickedTornadoSnapshot = null!;
+        world.Events.Add(22.48f, () =>
+        {
+            dummies[2]?.NativeActionEffect(
+                ActionId.WickedTornado,
+                2.1f,
+                (ushort)ActionId.WickedTornado,
+                0,
+                ActionType.Action,
+                0,
+                animationTargetId: dummies[2]!.GameObjectId
+                );
+
+            wickedTornadoSnapshot = party.Find.InsideActionAoe(ActionId.WickedTornado, dummies[2]!.Placement(), size: 7); // 7 is ActionId.WickedWheelAwaken's EffectRange
+        });
+
+        world.Events.Add(22.98f, () => ResolveSnapshot(wickedTornadoSnapshot, "Wicked Tornado"));
+
+        world.Events.Add(25.25f, () =>
+        {
+            garuda?.PlayActionTimeline(ActionTimelineId.WarpStart2);
+            SetFeatherRainPositions();
+        });
+
+        FeatherRain(26.72f, 27.70f);
+    }
+
+    private void GarudaPost()
+    {
+        GarudaSister(new Placement(new Vector3(15, 0, 0), -90), BNpcNameId.Chirada);
+        GarudaSister(new Placement(new Vector3(-15, 0, 0), 90), BNpcNameId.Suparna);
+
+        world.Events.Add(64.38f, () =>
+        {
+            garuda?.SetPosition(
+                new Placement(
+                    new Vector3(0f, 0f, 0f),
+                    0
+                    ));
+
+            garuda?.PlayActionTimeline(ActionTimelineId.WarpEnd);
+        });
+
+        world.Events.Add(68.61f, () => garuda?.NativeCast(
+            ActionId.MistralShriek,
+            ActionType.Action,
+            0f,
+            2.7f,
+            false,
+            targetId: garuda.GameObjectId
+            ));
+
+        world.Events.Add(71.57f, () => garuda?.NativeActionEffect(
+            ActionId.MistralShriek,
+            2.3f,
+            (ushort)ActionId.MistralShriek,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: garuda.GameObjectId
+            ));
+
+        // Technically these are for the Sisters. But adding it to their code section will duplicate the amount (10) that the actual fight uses (5), so it's kept here.
+        world.Events.Add(72.49f, SetFeatherRainPositions);
+        FeatherRain(73.91f, 74.87f); 
+
+        // These are the proper Garuda Feather Rains
+        world.Events.Add(76.04f, () =>
+        {
+            garuda?.PlayActionTimeline(ActionTimelineId.WarpStart2);
+            SetFeatherRainPositions();
+        });
+
+        FeatherRain(77.46f, 78.41f);
+    }
+
+    private void Ifrit()
+    {
+        world.Events.Add(12.03f, () => ifrit?.SetPosition(state.IfritPlacement));
+
+        world.Events.Add(12.28f, () =>
+        {
+            ifrit?.SetVisible(true);
+            ifrit?.PlayActionTimeline(ActionTimelineId.WarpEnd);
+        });
+
+        world.Events.Add(17.52f, () => ifrit?.NativeCast(
+            ActionId.CrimsonCyclone,
+            ActionType.Action,
+            0f,
+            2.7f,
+            false,
+            targetId: ifrit.GameObjectId
+            ));
+
+        IReadOnlyList<SimCharacter> crimsonCycloneSnapshot = null!;
+        world.Events.Add(20.22f, () => crimsonCycloneSnapshot = party.Find.InsideActionAoe(ActionId.CrimsonCyclone, ifrit!.Placement()));
+
+        world.Events.Add(20.43f, () => ifrit?.NativeActionEffect(
+            ActionId.CrimsonCyclone,
+            2.1f,
+            (ushort)ActionId.CrimsonCyclone,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: ifrit.GameObjectId
+            ));
+
+        world.Events.Add(20.69f, () => ResolveSnapshot(crimsonCycloneSnapshot, "Crimson Cyclone"));
+
+        CrimsonCycloneAwaken(Geometry.CrimsonCycloneAwakenPlacements[0], 11);
+        CrimsonCycloneAwaken(Geometry.CrimsonCycloneAwakenPlacements[1], 12);
+    }
+
+    private void IfritPost()
+    {
+        var dpsRole = state.Rng.NextDpsRole();
+        var dps = party.Get(dpsRole);
+
+        var ot = party.Get(PartyRole.OffTank);
+
+        world.Events.Add(36.74f, () => ifrit?.SetPosition(
+             new Placement(
+                 new Vector3(0f, 0f, -19.5f),
+                 0
+             )));
+
+        world.Events.Add(36.99f, () => ifrit?.PlayActionTimeline(ActionTimelineId.WarpEnd));
+
+        world.Events.Add(39.03f, () => ifrit?.NativeCast(
+            ActionId.EruptionIfrit,
+            ActionType.Action,
+            0f,
+            2.2f,
+            false,
+            targetId: ifrit.GameObjectId
+            ));
+
+        Eruption(39.03f, 42.05f, 11);
+        Eruption(41.13f, 43.94f, 9);
+
+        world.Events.Add(41.59f, () => ifrit?.NativeActionEffect(
+            ActionId.EruptionIfrit,
+            2.4f,
+            (ushort)ActionId.EruptionIfrit,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: ifrit.GameObjectId
+            ));
+
+        Eruption(43.02f, 46.15f, 11);
+        Eruption(45.15f, 48.13f, 9);
+
+        // TODO: Actual Infernal Fetters logic
+        world.Events.Add(46.94f, () => world.Tether(dps, ot, TetherId.InfernalFetters, 21, StatusId.InfernalFetters));
+
+        // Infernal Fetters VFX is handled by dummies[11] and dummies[12]
+        world.Events.Add(47.19f, () =>
+        {
+            dummies[11]?.NativeActionEffect(
+                ActionId.InfernalFetters,
+                0.6f,
+                (ushort)ActionId.InfernalFetters,
+                0,
+                ActionType.Action,
+                0,
+                animationTargetId: dps!.GameObjectId
+                );
+
+            dummies[12]?.NativeActionEffect(
+                ActionId.InfernalFetters,
+                0.6f,
+                (ushort)ActionId.InfernalFetters,
+                0,
+                ActionType.Action,
+                0,
+                animationTargetId: ot!.GameObjectId
+                );
+        });
+
+        world.Events.Add(49.05f, () => ifrit?.PlayActionTimeline(ActionTimelineId.WarpStart));
+    }
+
+    private void Titan()
+    {
+        world.Events.Add(12.03f, () => titan?.SetPosition(state.TitanPlacement));
+
+        world.Events.Add(12.28f, () =>
+        {
+            titan?.SetVisible(true);
+            titan?.PlayActionTimeline(ActionTimelineId.WarpEnd);
+        });
+
+        world.Events.Add(18.22f, () => titan?.NativeCast(
+            ActionId.LandslideTitan,
+            ActionType.Action,
+            0f,
+            1.9f,
+            false,
+            targetId: titan.GameObjectId
+            ));
+
+        Landslide(18.22f, 20.43f, 8, LandslideType.Normal);
+
+        world.Events.Add(20.43f, () => titan?.NativeActionEffect(
+            ActionId.LandslideTitan,
+            4.1f,
+            (ushort)ActionId.LandslideTitan,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: titan.GameObjectId
+            ));
+
+        Landslide(20.43f, 22.48f, 3, LandslideType.Awaken);
+
+        world.Events.Add(25.50f, () => titan?.PlayActionTimeline(ActionTimelineId.WarpStart));
+    }
+
+    private void TitanPost()
+    {
+        world.Events.Add(47.88f, () =>
+        {
+            var positions = new Placement[]
+            {
+                new(new(-13.7f, 0, -13.7f), Geometry.LookAtCenterRotation[DirectionEnum.NW]),
+                new(new(13.7f, 0, -13.7f), Geometry.LookAtCenterRotation[DirectionEnum.NE]),
+                new(new(13.7f, 0, 13.7f), Geometry.LookAtCenterRotation[DirectionEnum.SE]),
+                new(new(-13.7f, 0, 13.7f), Geometry.LookAtCenterRotation[DirectionEnum.SW])
+            };
+
+            var ultimaPosition2 = new Vector2(ultima!.Position.X, ultima!.Position.Z);
+
+            var furthest = positions
+            .OrderByDescending(x => Vector2.DistanceSquared(x.Position2, ultimaPosition2))
+            .First();
+
+            titan?.SetPosition(furthest);
+        });
+
+        world.Events.Add(48.13f, () => titan?.PlayActionTimeline(ActionTimelineId.WarpEnd));
+
+        world.Events.Add(50.28f, () => titan?.NativeActionEffect(
+            ActionId.BoulderTitan,
+            2.1f,
+            (ushort)ActionId.BoulderTitan,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: titan.GameObjectId
+            ));
+
+        var boulderPositions = state.Rng.RandomStart(Geometry.TitanBoulderPositions.ToArray());
+
+        BombBoulder(52.70f, 53.19f, 55.34f, 58.73f, 58.99f, 60.37f, boulderPositions[0]);
+        BombBoulder(54.65f, 55.34f, 57.25f, 60.82f, 61.04f, 62.29f, boulderPositions[1]);
+        BombBoulder(56.75f, 57.25f, 59.24f, 62.74f, 62.99f, 64.17f, boulderPositions[2]);
+        BombBoulder(58.73f, 59.24f, 61.29f, 64.89f, 65.14f, 66.39f, boulderPositions[3]);
+        BombBoulder(60.62f, 61.29f, 63.24f, 66.87f, 67.11f, 66.39f, boulderPositions[4]);
+        BombBoulder(62.74f, 63.24f, 65.39f, 68.86f, 69.11f, 70.26f, boulderPositions[5]);
+
+        world.Events.Add(54.45f, () =>
+        {
+            var bait = party.GetRandom();
+            titan?.Face(bait);
+
+            titan?.NativeCast(
+                ActionId.LandslideTitan,
+                ActionType.Action,
+                0f,
+                1.9f,
+                false,
+                targetId: titan.GameObjectId
+                );
+        });
+
+        Landslide(54.45f, 56.50f, 8, LandslideType.Normal);
+
+        world.Events.Add(56.50f, () => titan?.NativeActionEffect(
+            ActionId.LandslideTitan,
+            4.1f,
+            (ushort)ActionId.LandslideTitan,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: titan.GameObjectId
+            ));
+
+        Landslide(56.50f, 58.49f, 0, LandslideType.Awaken);
+
+        world.Events.Add(61.79f, () => titan?.NativeActionEffect(
+            ActionId.Tumult,
+            1.1f,
+            (ushort)ActionId.Tumult,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: titan.GameObjectId
+            ));
+
+        world.Events.Add(62.79f, () => titan?.NativeActionEffect(
+            ActionId.Tumult,
+            1.1f,
+            (ushort)ActionId.Tumult,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: titan.GameObjectId
+            ));
+
+        world.Events.Add(63.91f, () => titan?.NativeActionEffect(
+            ActionId.Tumult,
+            1.1f,
+            (ushort)ActionId.Tumult,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: titan.GameObjectId
+            ));
+
+        world.Events.Add(65.14f, () => titan?.NativeActionEffect(
+            ActionId.Tumult,
+            1.1f,
+            (ushort)ActionId.Tumult,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: titan.GameObjectId
+            ));
+
+        world.Events.Add(66.14f, () => titan?.NativeActionEffect(
+            ActionId.Tumult,
+            1.1f,
+            (ushort)ActionId.Tumult,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: titan.GameObjectId
+            ));
+
+        world.Events.Add(67.27f, () => titan?.NativeActionEffect(
+            ActionId.Tumult,
+            1.1f,
+            (ushort)ActionId.Tumult,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: titan.GameObjectId
+            ));
+
+        world.Events.Add(68.36f, () => titan?.NativeActionEffect(
+            ActionId.Tumult,
+            1.1f,
+            (ushort)ActionId.Tumult,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: titan.GameObjectId
+            ));
+
+        world.Events.Add(69.61f, () => titan?.PlayActionTimeline(ActionTimelineId.WarpStart));
+    }
+
+    private void Awaken(SimEnemy enemy, bool isUltima)
+    {
+        enemy?.AddStatusParam(StatusId.Woken, isUltima ? 97 : 0);
+        TimelineContainerPointers.SetAnimationState(&enemy!.BattleCharaPtr->Timeline, 0, 1);
+    }
+
+    private void RadiantPlume(Vector3 position, int dummyIndex)
+    {
+        world.Events.Add(49.05f, () => dummies[dummyIndex]?.NativeCast(
+            ActionId.RadiantPlumePuddle,
+            ActionType.Action,
+            0f,
+            3.7f,
+            false,
+            rotation: float.Pi,
+            position: position
+            ));
+
+        IReadOnlyList<SimCharacter> radiantPlumeSnapshot = null!;
+        world.Events.Add(52.75f, () => radiantPlumeSnapshot = party.Find.InsideActionAoe(ActionId.RadiantPlumePuddle, new(position, 0)));
+
+        world.Events.Add(52.95f, () => dummies[dummyIndex]?.NativeActionEffect(
+            ActionId.RadiantPlumePuddle,
+            0.1f,
+            (ushort)ActionId.RadiantPlumePuddle,
+            0,
+            ActionType.Action,
+            0,
+            position: position
+            ));
+
+        world.Events.Add(53.61f, () => ResolveSnapshot(radiantPlumeSnapshot, "Radiant Plume"));
+    }
+
+    private void SetFeatherRainPositions()
+    {
+        featherRainPositions.Clear();
+        var players = RoleList.Random(party, 5);
+
+        for (int i = 0; i < 5; i++)
+        {
+            featherRainPositions.Add(players.Get(i)!.Position);
+        }
+    }
+
+    private void FeatherRain(float castOffset, float effectOffset)
+    {
+        world.Events.Add(castOffset, () =>
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                var dummy = dummies[8 + i];
+
+                dummy?.SetPosition(
+                    new Placement(
+                        featherRainPositions[i],
+                        0
+                        ));
+
+                dummy?.NativeCast(
+                    ActionId.FeatherRain,
+                    ActionType.Action,
+                    0f,
+                    0.7f,
+                    false
+                    );
+            }
+        });
+
+        var featherRainSnapshots = new List<IReadOnlyList<SimCharacter>>();
+        world.Events.Add(castOffset + 0.7f, () =>
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                var dummy = dummies[8 + i];
+                featherRainSnapshots.Add(party.Find.InsideActionAoe(ActionId.FeatherRain, dummy!.Placement()));
+            }
+        });
+
+        world.Events.Add(effectOffset, () =>
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                var dummy = dummies[8 + i];
+
+                dummy?.NativeActionEffect(
+                    ActionId.FeatherRain,
+                    1.1f,
+                    (ushort)ActionId.FeatherRain,
+                    0,
+                    ActionType.Action,
+                    0,
+                    position: dummy.Position
+                    );
+            }
+        });
+
+        world.Events.Add(effectOffset + 0.2f, () =>
+        {
+            foreach (var featherRainSnapshot in featherRainSnapshots)
+            {
+                ResolveSnapshot(featherRainSnapshot, "Feather Rain");
+            }
+        });
+    }
+
+    private void GarudaSister(Placement placement, uint nameId)
+    {
+        SimEnemy? sister = null;
+
+        world.Events.Add(64.38f, () =>
+        {
+            sister = world.SpawnEnemy(
+                new EnemySpawnConfig(
+                    BNpcBaseId: BNpcBaseId.SuparnaChirada,
+                    NameId: nameId,
+                    Level: 70,
+                    Targetable: false,
+                    EnemyList: EnemyListMode.Never,
+                    IsVisible: true,
+                    Placement: placement)
+            );
+
+            sister?.PlayActionTimeline(ActionTimelineId.WarpEnd);
+        });
+
+        world.Events.Add(66.64f, () => sister?.NativeCast(
+            ActionId.WickedWheel,
+            ActionType.Action,
+            0f,
+            2.7f,
+            false,
+            targetId: sister.GameObjectId
+            ));
+
+        IReadOnlyList<SimCharacter> wickedWheelSnapshot = null!;
+        world.Events.Add(69.34f, () => wickedWheelSnapshot = party.Find.InsideActionAoe(ActionId.WickedWheel, placement));
+
+        world.Events.Add(69.61f, () => sister?.NativeActionEffect(
+            ActionId.WickedWheel,
+            2.8f,
+            (ushort)ActionId.WickedWheel,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: sister.GameObjectId
+            ));
+
+        world.Events.Add(70.71f, () => ResolveSnapshot(wickedWheelSnapshot, "Wicked Wheel"));
+
+        world.Events.Add(72.49f, () => sister?.PlayActionTimeline(ActionTimelineId.WarpStart2));
+
+        world.Events.Add(74.37f, () => sister?.SetPosition(
+             new Placement(
+                 new Vector3(0f, 0f, -19.5f),
+                 0
+             )));
+    }
+
+    private void CrimsonCycloneAwaken(Placement placement, int dummyIndex)
+    {
+        IReadOnlyList<SimCharacter> crimsonCycloneAwakenSnapshot = null!;
+        world.Events.Add(22.48f, () =>
+        {
+            var dummy = dummies[dummyIndex];
+
+            dummy?.SetPosition(placement);
+
+            dummy?.NativeActionEffect(
+                ActionId.CrimsonCycloneAwaken,
+                2.1f,
+                (ushort)ActionId.CrimsonCycloneAwaken,
+                0,
+                ActionType.Action,
+                0,
+                animationTargetId: dummy.GameObjectId
+                );
+
+            crimsonCycloneAwakenSnapshot = party.Find.InsideActionAoe(ActionId.CrimsonCycloneAwaken, dummy!.Placement());
+        });
+
+        world.Events.Add(22.95f, () => ResolveSnapshot(crimsonCycloneAwakenSnapshot, "Crimson Cyclone (Awaken)"));
+    }
+
+    private void Eruption(float castOffset, float effectOffset, int dummyStartIndex)
+    {
+        var position1 = Vector3.Zero;
+        var position2 = Vector3.Zero;
+
+        world.Events.Add(castOffset, () =>
+        {
+            var baits = party.Find.FarestN(ifrit!.Position, 2);
+
+            position1 = baits[0].Position;
+            position2 = baits[1].Position;
+
+            dummies[dummyStartIndex]?.NativeCast(
+                ActionId.EruptionPuddle,
+                ActionType.Action,
+                0f,
+                2.7f,
+                false,
+                rotation: float.Pi,
+                position: position1
+                );
+
+            dummies[dummyStartIndex + 1]?.NativeCast(
+                ActionId.EruptionPuddle,
+                ActionType.Action,
+                0f,
+                2.7f,
+                false,
+                rotation: float.Pi,
+                position: position2
+                );
+        });
+
+        IReadOnlyList<SimCharacter> eruptionSnapshot1 = null!;
+        IReadOnlyList<SimCharacter> eruptionSnapshot2 = null!;
+        world.Events.Add(castOffset + 2.7f, () =>
+        {
+            eruptionSnapshot1 = party.Find.InsideActionAoe(ActionId.EruptionPuddle, new(position1, 0));
+            eruptionSnapshot2 = party.Find.InsideActionAoe(ActionId.EruptionPuddle, new(position2, 0));
+        });
+
+        world.Events.Add(effectOffset, () =>
+        {
+            dummies[dummyStartIndex]?.NativeActionEffect(
+                ActionId.EruptionPuddle,
+                0.1f,
+                (ushort)ActionId.EruptionPuddle,
+                0,
+                ActionType.Action,
+                0,
+                rotation: 0,
+                position: position1
+                );
+
+            dummies[dummyStartIndex + 1]?.NativeActionEffect(
+                ActionId.EruptionPuddle,
+                0.1f,
+                (ushort)ActionId.EruptionPuddle,
+                0,
+                ActionType.Action,
+                0,
+                rotation: 0,
+                position: position2
+                );
+        });
+
+        world.Events.Add(effectOffset + 0.66f, () =>
+        {
+            ResolveSnapshot(eruptionSnapshot1, "Eruption");
+            ResolveSnapshot(eruptionSnapshot2, "Eruption");
+        });
+    }
+
+    private void Landslide(float castOffset, float effectOffset, int dummyStartIndex, LandslideType type)
+    {
+        float[] rotationOffsets;
+        uint actionId;
+        float castTime;
+        float animationLock;
+
+        switch (type)
+        {
+            case LandslideType.Normal:
+                rotationOffsets = Geometry.TitanLandslideOffsets.ToArray();
+                actionId = ActionId.LandslideLine;
+                castTime = 1.9f;
+                animationLock = 2.1f;
+                break;
+            case LandslideType.Awaken:
+                rotationOffsets = Geometry.TitanLandslideAwakenOffsets.ToArray();
+                actionId = ActionId.LandslideAwaken;
+                castTime = 1.7f;
+                animationLock = 1.1f;
+                break;
+            case LandslideType.Ultima:
+                rotationOffsets = Geometry.UltimaLandslideOffsets.ToArray();
+                actionId = ActionId.LandslideLineUltima;
+                castTime = 1.9f;
+                animationLock = 1.1f;
+                break;
+            default:
+                throw new Exception($"[UltimatePredationScenario.Landslide] Unsupported LandslideType {type}");
+        }
+
+        world.Events.Add(castOffset, () =>
+        {
+            var enemy = type == LandslideType.Ultima ? ultima : titan;
+
+            for (int i = 0; i < rotationOffsets.Length; i++)
+            {
+                var dummy = dummies[dummyStartIndex + i];
+
+                dummy?.SetPosition(
+                    new Placement(
+                        enemy!.Position,
+                        enemy.Rotation + rotationOffsets[i]
+                        ));
+
+                dummy?.NativeCast(
+                    actionId,
+                    ActionType.Action,
+                    0f,
+                    castTime,
+                    false,
+                    targetId: dummy.GameObjectId
+                    );
+            }
+        });
+
+        var landslideSnapshots = new List<IReadOnlyList<SimCharacter>>();
+        world.Events.Add(castOffset + castTime, () =>
+        {
+            for (int i = 0; i < rotationOffsets.Length; i++)
+            {
+                var dummy = dummies[dummyStartIndex + i];
+                var snapshot = party.Find.InsideActionAoe(actionId, dummy!.Placement());
+                landslideSnapshots.Add(snapshot);
+            }
+        });
+
+        world.Events.Add(effectOffset, () =>
+        {
+            for (int i = 0; i < rotationOffsets.Length; i++)
+            {
+                var dummy = dummies[dummyStartIndex + i];
+
+                dummy?.NativeActionEffect(
+                    actionId,
+                    animationLock,
+                    (ushort)actionId,
+                    0,
+                    ActionType.Action,
+                    0,
+                    animationTargetId: dummy.GameObjectId
+                    );
+            }
+        });
+
+        world.Events.Add(effectOffset + 0.73f, () =>
+        {
+            var enemy = type == LandslideType.Ultima ? ultima : titan;
+
+            foreach (var landslideSnapshot in landslideSnapshots)
+            {
+                foreach (var character in landslideSnapshot)
+                {
+                    // TODO: "30" and "50" are from Titan EX, but doubled. Need to find the proper UWU values.
+                    (character as ISimPartyMember)?.Knockback(enemy!.Position, 30, 50);
+                }
+            }
+        });
+    }
+
+    private void BombBoulder(float spawnOffset, float buryOffset, float castOffset, float effectOffset, float fadeOffset, float despawnOffset, Vector3 position)
+    {
+        SimEnemy? boulder = null;
+
+        world.Events.Add(spawnOffset, () => boulder = world.SpawnEnemy(
+            new EnemySpawnConfig(
+                BNpcBaseId: BNpcBaseId.BombBoulder,
+                NameId: BNpcNameId.BombBoulder,
+                Level: 70,
+                Targetable: false,
+                EnemyList: EnemyListMode.Never,
+                IsVisible: false,
+                Placement: new(position, 0)
+                )
+            )
+        );
+
+        IReadOnlyList<SimCharacter> burySnapshot = null!;
+        world.Events.Add(buryOffset, () =>
+        {
+            boulder?.SetVisible(true);
+
+            boulder?.NativeActionEffect(
+            ActionId.Bury,
+            0.6f,
+            (ushort)ActionId.Bury,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: boulder.GameObjectId
+            );
+
+            burySnapshot = party.Find.InsideActionAoe(ActionId.Bury, boulder!.Placement());
+        });
+
+        world.Events.Add(buryOffset + 0.53f, () => ResolveSnapshot(burySnapshot, "Bury"));
+
+        world.Events.Add(castOffset, () => boulder?.NativeCast(
+            ActionId.Burst,
+            ActionType.Action,
+            0f,
+            3.2f,
+            false,
+            targetId: boulder.GameObjectId
+            )
+        );
+
+        IReadOnlyList<SimCharacter> burstSnapshot = null!;
+        world.Events.Add(castOffset + 3.2f, () => burstSnapshot = party.Find.InsideActionAoe(ActionId.Burst, boulder!.Placement()));
+
+        world.Events.Add(effectOffset, () => boulder?.NativeActionEffect(
+            ActionId.Burst,
+            2.1f,
+            (ushort)ActionId.Burst,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: boulder.GameObjectId
+            )
+        );
+
+        world.Events.Add(effectOffset + 0.16f, () => ResolveSnapshot(burstSnapshot, "Burst"));
+
+        world.Events.Add(fadeOffset, () => PacketDispatcher.HandleActorControlPacket(boulder!.EntityId, 607, boulder.EntityId, 1, 0, 100, 0, 0, 0, 0, 0xE0000000, false));
+        world.Events.Add(despawnOffset, () => boulder?.Despawn());
+    }
+
+    private void ResolveSnapshot(IReadOnlyList<SimCharacter> snapshot, string dieCause)
+    {
+        foreach (var character in snapshot)
+        {
+            character.Die(dieCause);
+        }
+    }
+
+    private void ResolveSnapshotTankbuster(IReadOnlyList<SimCharacter> snapshot, string dieCause)
+    {
+        foreach (var character in snapshot)
+        {
+            if (character is not ISimPartyMember { Role: PartyRole.MainTank or PartyRole.OffTank })
+            {
+                character.Die($"{dieCause} (Tank Buster)");
+            }
+        }
+    }
+
+    private enum LandslideType
+    {
+        Normal,
+        Awaken,
+        Ultima
+    }
+}

--- a/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationScenarioObjects.cs
+++ b/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationScenarioObjects.cs
@@ -1,0 +1,8 @@
+using AnoMech.Core.SimObjects;
+
+namespace AnoMech.Scenarios.Uwu.UltimatePredation;
+
+public class UltimatePredationScenarioObjects
+{
+    public SimEnemy? Titan { get; set; }
+}

--- a/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationSettingsWindow.cs
+++ b/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationSettingsWindow.cs
@@ -1,0 +1,36 @@
+using Dalamud.Bindings.ImGui;
+
+namespace AnoMech.Scenarios.Uwu.UltimatePredation;
+
+public class UltimatePredationSettingsWindow
+{
+    public UltimatePredationStateOverrides Overrides { get; } = new();
+
+    public void Draw()
+    {
+        if (ImGui.Button("Auto"))
+        {
+            ResetAll();
+        }
+
+        if (SettingsGrid.Begin("##ultimatepredation"))
+        {
+            DrawCenterDodge();
+            SettingsGrid.End();
+        }
+    }
+
+    private void DrawCenterDodge()
+    {
+        var v = Overrides.CenterDodge;
+        SettingsGrid.Row("Boss Positions:");
+        if (ImGui.RadioButton("Random##centerdodge", v == null)) Overrides.CenterDodge = null;
+        ImGui.SameLine();
+        if (ImGui.RadioButton("Center Dodge##centerdodge", v == true)) Overrides.CenterDodge = true;
+    }
+
+    private void ResetAll()
+    {
+        Overrides.CenterDodge = null;
+    }
+}

--- a/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationState.cs
+++ b/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationState.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using AnoMech.Core.Game;
+using static AnoMech.Scenarios.Uwu.UwuConstants;
+
+namespace AnoMech.Scenarios.Uwu.UltimatePredation;
+
+public class UltimatePredationState
+{
+    public Placement UltimaPlacement { get; init; }
+    public Placement GarudaPlacement { get; init; }
+    public Placement IfritPlacement { get; init; }
+    public Placement TitanPlacement { get; init; }
+    public UltimatePredationScenarioObjects ScenarioObjects { get; } = new();
+
+    public readonly Rng Rng = new();
+
+    public UltimatePredationState(UltimatePredationStateOverrides overrides)
+    {
+        var centerDodge = overrides.CenterDodge ?? false;
+
+        (GarudaPlacement, var garudaIntercardinal) = GetPlacement(Geometry.GarudaPlacements);
+        (UltimaPlacement, var ultimaIntercardinal) = GetPlacement(Geometry.UltimaPlacements, centerDodge ? [garudaIntercardinal] : null);
+        (IfritPlacement, _) = GetPlacement(Geometry.IfritPlacements, [ultimaIntercardinal]);
+        TitanPlacement = GetTitanPlacement(Geometry.TitanPlacements, centerDodge);
+
+#if DEBUG
+        Plugin.Log.Debug("[UltimatePredationState]\n" +
+            $"UltimaPlacement = {UltimaPlacement.Position2}\n" +
+            $"GarudaPlacement = {GarudaPlacement.Position2}\n" +
+            $"IfritPlacement = {IfritPlacement.Position2}\n" +
+            $"TitanPlacement = {TitanPlacement.Position2}");
+#endif
+    }
+
+    private (Placement Placement, DirectionEnum Intercardinal) GetPlacement(IDictionary<DirectionEnum, Placement> possiblePlacements, List<DirectionEnum>? ignoreDirections = null)
+    {
+        IDictionary<DirectionEnum, Placement> dict;
+
+        if (ignoreDirections == null)
+        {
+            dict = possiblePlacements;
+        }
+        else
+        {
+            dict = new Dictionary<DirectionEnum, Placement>(possiblePlacements);
+            ignoreDirections.ForEach(x => dict.Remove(x));
+        }
+
+        var key = Rng.NextObj(dict.Keys.ToArray());
+        return (dict[key], key);
+    }
+
+    private Placement GetTitanPlacement(IDictionary<DirectionEnum, Placement> possiblePlacements, bool centerDodge)
+    {
+        const float Offset = 3;
+
+        if (!centerDodge)
+        {
+            (var placement, _) = GetPlacement(possiblePlacements);
+
+            var distance = Rng.NextBool() ? Offset : -Offset;
+            return placement.MoveRight(distance);
+        }
+        else
+        {
+            List<DirectionEnum> ignore;
+            var ignoreClosest = Rng.NextBool();
+
+            if (ignoreClosest)
+            {
+                ignore = possiblePlacements
+                    .OrderBy(x => Vector2.DistanceSquared(x.Value.Position2, GarudaPlacement.Position2))
+                    .Take(2)
+                    .Select(x => x.Key)
+                    .ToList();
+            }
+            else
+            {
+                ignore = possiblePlacements
+                    .OrderByDescending(x => Vector2.DistanceSquared(x.Value.Position2, GarudaPlacement.Position2))
+                    .Take(2)
+                    .Select(x => x.Key)
+                    .ToList();
+            }
+
+            (var cardinal, _) = GetPlacement(possiblePlacements, ignore);
+
+            var offsets = new Placement[]
+            {
+                cardinal.MoveRight(-Offset),
+                cardinal.MoveRight(Offset)
+            };
+
+            if (ignoreClosest)
+            {
+                return offsets
+                    .OrderBy(x => Vector2.DistanceSquared(x.Position2, GarudaPlacement.Position2))
+                    .First();
+            }
+            else
+            {
+                return offsets
+                    .OrderByDescending(x => Vector2.DistanceSquared(x.Position2, GarudaPlacement.Position2))
+                    .First();
+            }
+        }
+    }
+}

--- a/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationStateOverrides.cs
+++ b/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationStateOverrides.cs
@@ -1,0 +1,10 @@
+namespace AnoMech.Scenarios.Uwu.UltimatePredation;
+
+public class UltimatePredationStateOverrides
+{
+    /// <value>
+    /// If <see langword="null"/>, the bosses will be positioned randomly.
+    /// If not <see langword="null"/> and <see langword="true"/>, the bosses will be positioned semi-randomly, allowing to execute the center dodge.
+    /// </value>
+    public bool? CenterDodge { get; set; }
+}

--- a/AnoMech/Scenarios/Uwu/UwuConstants.cs
+++ b/AnoMech/Scenarios/Uwu/UwuConstants.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Numerics;
+using AnoMech.Core.Game;
+
+namespace AnoMech.Scenarios.Uwu;
+
+public class UwuConstants
+{
+    public const byte Level = 70;
+    public const ushort ItemLevel = 375;
+
+    public static IReadOnlyList<Waymark> NaurWaymarks =>
+    [
+        new(WaymarkSlot.A, new Vector3(0, 0, -6.7f)),
+        new(WaymarkSlot.B, new Vector3(6.7f, 0, 0)),
+        new(WaymarkSlot.C, new Vector3(0, 0, 6.7f)),
+        new(WaymarkSlot.D, new Vector3(-6.7f, 0, 0)),
+        new(WaymarkSlot.One, new Vector3(7.3f, 0, 7.3f)),
+        new(WaymarkSlot.Two, new Vector3(6, 0, -19)),
+        new(WaymarkSlot.Three, new Vector3(0, 0, 0)),
+        new(WaymarkSlot.Four, new Vector3(-13, 0, -13)),
+    ];
+
+    public class BNpcBaseId
+    {
+        public const uint Garuda = 8722;
+        public const uint SuparnaChirada = 8723;
+        public const uint Titan = 8727;
+        public const uint BombBoulder = 8728;
+        public const uint Ifrit = 8730;
+        public const uint UltimaWeapon = 8734;
+        public const uint Dummy = 9020;
+    }
+
+    public class BNpcNameId
+    {
+        public const uint Dummy = 108;
+        public const uint BombBoulder = 1803;
+        public const uint Ifrit = 1185;
+        public const uint Garuda = 1644;
+        public const uint Suparna = 1645;
+        public const uint Chirada = 1646;
+        public const uint Titan = 1801;
+        public const uint UltimaWeapon = 2137;
+    }
+
+    public class ActionId
+    {
+        public const uint WickedWheel = 11084;
+        public const uint FeatherRain = 11085;
+        public const uint WickedWheelAwaken = 11086;
+        public const uint WickedTornado = 11087;
+        public const uint MistralShriek = 11092;
+        public const uint EruptionIfrit = 11097;
+        public const uint EruptionPuddle = 11098;
+        public const uint CrimsonCyclone = 11103;
+        public const uint CrimsonCycloneAwaken = 11104;
+        public const uint RadiantPlumePuddle = 11105;
+        public const uint BoulderTitan = 11112;
+        public const uint Bury = 11113;
+        public const uint Burst = 11114;
+        public const uint LandslideLine = 11120;
+        public const uint LandslideTitan = 11121;
+        public const uint UltimatePredation = 11126;
+        public const uint ViscousAetheroplasmUltima = 11129;
+        public const uint ViscousAetheroplasmEffect = 11130;
+        public const uint HomingLasers = 11131;
+        public const uint CeruleumVent = 11132;
+        public const uint RadiantPlumeUltima = 11133;
+        public const uint LandslideUltima = 11134;
+        public const uint LandslideLineUltima = 11135;
+        public const uint Tumult = 11288;
+        public const uint InfernalFetters = 11289;
+        public const uint LandslideAwaken = 11298;
+        public const uint PostUltimatePredation1 = 11475;
+        public const uint PostUltimatePredation2 = 11476;
+        public const uint PostUltimatePredation3 = 11477;
+        public const uint UltimateAnnihilation = 11596;
+    }
+
+    public class ActionTimelineId
+    {
+        public const ushort WarpStart = 7737;
+        public const ushort WarpStart2 = 7738;
+        public const ushort WarpEnd = 7747;
+    }
+
+    public class StatusId
+    {
+        public const ushort InfernalFetters = 377;
+        public const ushort Woken = 1529;
+    }
+
+    public class TetherId
+    {
+        public const ushort InfernalFetters = 9;
+    }
+
+    public class Geometry
+    {
+        public const float ArenaRadius = 19.4f;
+        public const float WickedTornadoOuterRadius = 20; // 20 is the EffectRange in the Action sheet
+
+        public static readonly FrozenDictionary<DirectionEnum, float> LookAtCenterRotation;
+        public static readonly FrozenDictionary<DirectionEnum, Placement> UltimaPlacements;
+        public static readonly FrozenDictionary<DirectionEnum, Placement> GarudaPlacements;
+        public static readonly FrozenDictionary<DirectionEnum, Placement> IfritPlacements;
+        public static readonly FrozenDictionary<DirectionEnum, Placement> TitanPlacements;
+        public static ReadOnlySpan<Placement> CrimsonCycloneAwakenPlacements => CrimsonCycloneAwakenPlacementsROM.Span;
+        public static ReadOnlySpan<float> TitanLandslideOffsets => TitanLandslideOffsetsROM.Span;
+        public static ReadOnlySpan<float> TitanLandslideAwakenOffsets => TitanLandslideAwakenOffsetsROM.Span;
+        public static ReadOnlySpan<Vector3> TitanBoulderPositions => TitanBoulderPositionsROM.Span;
+        public static ReadOnlySpan<Vector3> UltimaRadiantPlumePositions => UltimaRadiantPlumePositionsROM.Span;
+        public static ReadOnlySpan<float> UltimaLandslideOffsets => UltimaLandslideOffsetsROM.Span;
+
+        private static readonly ReadOnlyMemory<Placement> CrimsonCycloneAwakenPlacementsROM;
+        private static readonly ReadOnlyMemory<float> TitanLandslideOffsetsROM;
+        private static readonly ReadOnlyMemory<float> TitanLandslideAwakenOffsetsROM;
+        private static readonly ReadOnlyMemory<Vector3> TitanBoulderPositionsROM;
+        private static readonly ReadOnlyMemory<Vector3> UltimaRadiantPlumePositionsROM;
+        private static readonly ReadOnlyMemory<float> UltimaLandslideOffsetsROM;
+
+        static Geometry()
+        {
+            LookAtCenterRotation = new Dictionary<DirectionEnum, float>
+            {
+                { DirectionEnum.N, 0 },
+                { DirectionEnum.NE, float.DegreesToRadians(-45) },
+                { DirectionEnum.E, float.DegreesToRadians(-90) },
+                { DirectionEnum.SE, float.DegreesToRadians(-135) },
+                { DirectionEnum.S, float.DegreesToRadians(180) },
+                { DirectionEnum.SW, float.DegreesToRadians(135) },
+                { DirectionEnum.W, float.DegreesToRadians(90) },
+                { DirectionEnum.NW, float.DegreesToRadians(45) }
+            }.ToFrozenDictionary();
+
+            UltimaPlacements = GetIntercardinalPlacementDictionary(12);
+            GarudaPlacements = GetIntercardinalPlacementDictionary(3);
+            IfritPlacements = GetIntercardinalPlacementDictionary(13.7f);
+            TitanPlacements = new Dictionary<DirectionEnum, Placement>
+            {
+                { DirectionEnum.N, new(new(0, 0, -17), LookAtCenterRotation[DirectionEnum.N]) },
+                { DirectionEnum.E, new(new(17, 0, 0), LookAtCenterRotation[DirectionEnum.E]) },
+                { DirectionEnum.S, new(new(0, 0, 17), LookAtCenterRotation[DirectionEnum.S]) },
+                { DirectionEnum.W, new(new(-17, 0, 0), LookAtCenterRotation[DirectionEnum.W]) }
+            }.ToFrozenDictionary();
+
+            CrimsonCycloneAwakenPlacementsROM = new Placement[]
+            {
+                new(new(19.374725f, 0, 0), float.DegreesToRadians(-90)),
+                new(new(0, 0, -19.374725f), float.DegreesToRadians(0))
+            };
+
+            TitanLandslideOffsetsROM = new float[]
+            {
+                float.DegreesToRadians(-135),
+                float.DegreesToRadians(135),
+                float.DegreesToRadians(-45),
+                float.DegreesToRadians(45),
+                float.DegreesToRadians(0)
+            };
+
+            TitanLandslideAwakenOffsetsROM = new float[]
+            {
+                float.DegreesToRadians(-338),
+                float.DegreesToRadians(-22),
+                float.DegreesToRadians(-270),
+                float.DegreesToRadians(-90),
+                float.DegreesToRadians(-180)
+            };
+
+            TitanBoulderPositionsROM = new Vector3[]
+            {
+                new(-3, 0, -5), // NW
+                new(3, 0, -5), // NE
+                new(6, 0, 0), // E
+                new(3, 0, 5), // SE
+                new(-3, 0, 5), // SW
+                new(-6, 0, 0) // W
+            };
+
+            UltimaRadiantPlumePositionsROM = new Vector3[]
+            {
+                new(0, 0, 18),
+                new(11, 0, 11),
+                new(-11, 0, 11),
+                new(18, 0, 0),
+                new(-18, 0, 0),
+                new(11, 0, -11),
+                new(-11, 0, -11),
+                new(0, 0, -18)
+            };
+
+            UltimaLandslideOffsetsROM = new float[]
+            {
+                float.DegreesToRadians(0),
+                float.DegreesToRadians(45),
+                float.DegreesToRadians(315)
+            };
+        }
+
+        private static FrozenDictionary<DirectionEnum, Placement> GetIntercardinalPlacementDictionary(float offset)
+        {
+            return new Dictionary<DirectionEnum, Placement>
+            {
+                { DirectionEnum.NW, new(new(-offset, 0, -offset), LookAtCenterRotation[DirectionEnum.NW]) },
+                { DirectionEnum.NE, new(new(offset, 0, -offset), LookAtCenterRotation[DirectionEnum.NE]) },
+                { DirectionEnum.SE, new(new(offset, 0, offset), LookAtCenterRotation[DirectionEnum.SE]) },
+                { DirectionEnum.SW, new(new(-offset, 0, offset), LookAtCenterRotation[DirectionEnum.SW]) }
+            }.ToFrozenDictionary();
+        }
+    }
+
+    public enum DirectionEnum
+    {
+        N,
+        NE,
+        E,
+        SE,
+        S,
+        SW,
+        W,
+        NW
+    }
+}

--- a/AnoMech/Scenarios/Uwu/UwuUtils.cs
+++ b/AnoMech/Scenarios/Uwu/UwuUtils.cs
@@ -1,0 +1,12 @@
+using AnoMech.Helpers;
+
+namespace AnoMech.Scenarios.Uwu;
+
+public static class UwuUtils
+{
+    public static void UpdateArena(byte value)
+    {
+        byte[] unionData = [value];
+        InstanceContentDirectorHelper.SetDirectorData(1, 0, unionData, true);
+    }
+}


### PR DESCRIPTION
This PR implements an **Ultimate Predation** _(UWU)_ Scenario.

This implementation takes a different approach to the procedure used in already implemented Scenarios. Main difference being, this one is based on **Replay data** (hence it's heavy reliance on `NativeCast` and `NativeActionEffect`), instead of **ACT data**.

For foresight, in the case it's needed, the Waymarks and Strat is labeled as NAUR, as that's the strats used in the Replays utilized to make this implementation.

Aside from the Scenario additions themselves, these are the changes/additions made to help with this implementation:
- `CharacterFind` has a new `FarestN` method (side remark, using this as a suggestion to replace the logic of `ClosestN` so that it's more simple and readable).
- `Placement` has a new `MoveRight` method (side remark, using this too as a suggestion to replace the logic of `MoveForward` so that it's more simple).
- `SimCast.IsCasting` is now determined utilizing `CastInfo.IsCasting`, and `SimCast.IsBusy` now utilizes `SimCast.IsCasting` instead of `SimCast.casting`. This allows for casts executed directly with `SimCast.NativeCast` to be recognized properly.
- `SimCast.NativeActionEffect` now sets `remainingAnimationLock` with the `animationLock` argument. With this change, the `animationLock` argument of `SimCast.FireActionEffect` is now obligatory, and previous stray sets of `remainingAnimationLock` are now dealt with the `animationLock` argument.
- `SimCharacter` has a new `AddStatusParam` method. This allow for the usage of arbitrary Status param values, which while most of the time are used as stacks, there's some instances that specific values are used for other reasons. Like, Status ID **1529** _(Woken)_ needs to have a param value of 97 for Ultima, and a param value of 0 for the Primals.
- `SimEnemy` has a new `SetTarget` method. It has basic functionality, which is setting the `TargetId` of the native object, and then start following the target (if marked by the `follow` argument).
- `TimelineContainerPointers` has a new `SetAnimationState` method/signature. This is used to setup certain effects like Ultima's woken wings, or the Primals woken effects.
- `Rng` has a new `RandomStart` method, which takes an array and returns a copy that starts from a random index (and wraps if needed). This is used for the positions of Titan's boulders.

In the Scenario files, there's some **TODO** that has been left marked:
- For **Homing Lasers**, enmity management is expected to deal with the mechanic, but since there's a lack of an enmity system for now, it's left assumed and it's reflected in chat _(Assuming Tank Swap)_ to be clear with the user.
- For **Viscous Aetheroplasm**, it's usually resolved using an invulnerability, but since there's no invulnerability implementation yet, it's treated as a Tank Buster.
- While **Infernal Fetters** are there visually, they do nothing else than just being there. Might be worth implementing if an Ifrit scenario is made in the future, but considering this scenario deals with it in a way that makes it useless, no proper implementation is done yet.
- Some **Landslide** variations, like the ones in _Titan Extreme_, do make the player deal with the knockback locally, but in _UWU_, these seem to be completely managed by the server. For this reason, the knockback effect in the Landslides of this scenario, an assumption of double the speed and distance of _Titan EX_ is taken to use as a base for the `ISimPartyMember.Knockback` method call.