### PR TITLE
Adds the UMAD P5 "Exaflares" scenario

### DIFF
--- a/AnoMech/Core/Game/Game.cs
+++ b/AnoMech/Core/Game/Game.cs
@@ -14,6 +14,7 @@ using AnoMech.Scenarios.Top.P6WaveCannon2;
 using AnoMech.Scenarios.Umad.P2Forsaken;
 using AnoMech.Scenarios.Umad.P3BlackHole;
 using AnoMech.Scenarios.Umad.P4KefkaSays;
+using AnoMech.Scenarios.Umad.P5Exaflares;
 using AnoMech.Scenarios.Uwu.UltimatePredation;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
@@ -64,6 +65,7 @@ public sealed class Game : IDisposable
             new UmadP2ForsakenScenario(),
             new UmadP3BlackHoleScenario(),
             new UmadP4KefkaSaysScenario(),
+            new UmadP5ExaflaresScenario(),
             new TopP2PartySynergyScenario(),
             new TopP5DeltaScenario(),
             new TopP5SigmaScenario(),

--- a/AnoMech/Core/Game/Game.cs
+++ b/AnoMech/Core/Game/Game.cs
@@ -178,6 +178,9 @@ public sealed class Game : IDisposable
         }
     }
 
+    // Godmode preview: how long a swallowed-death HP-bar drop stays down before healing back.
+    private const float GodmodeHealSeconds = 1.2f;
+
     // Single entry point for "this character died". Always posts the cause
     // to chat and, on the first call of a run, fires the on-screen overlay
     // — both happen even in godmode so the user can learn what would have
@@ -206,7 +209,18 @@ public sealed class Game : IDisposable
             ShowFirstDeathOverlay(target, cause);
         }
 
-        if (GodMode) return false;
+        if (GodMode)
+        {
+            // Godmode swallows the death but still previews it: drop the player's bar and heal it
+            // back a beat later. Done here rather than OnKilled (which godmode skips) so every
+            // scenario gets it. Rides Game.Events; the ~1.2s restore is cosmetic, so scaling is moot.
+            if (target is SimPlayer player)
+            {
+                player.DropHpBar();
+                Events.Add(GodmodeHealSeconds, player.RestoreHpBar);
+            }
+            return false;
+        }
         target.OnKilled();
         if (!firstFreezeScheduled)
         {

--- a/AnoMech/Core/Native/DamageNumbers.cs
+++ b/AnoMech/Core/Native/DamageNumbers.cs
@@ -1,0 +1,47 @@
+using System;
+using AnoMech.Core.SimObjects;
+using Dalamud.Game.Gui.FlyText;
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
+
+namespace AnoMech.Core.Native;
+
+// Pops the floating damage number over a party member via the native _FlyText
+// addon (Dalamud's IFlyTextGui). Cosmetic only — HP/death live in DamageSolver.
+// Two entry points so a scenario passes whatever it has: Show for a literal number
+// (e.g. a value from logs), ShowFraction for the "hits for X% of your HP" case.
+internal static unsafe class DamageNumbers
+{
+    // ABGR. Red, matching the game's own physical/unmitigated damage tint.
+    private const uint DamageColorAbgr = 0xFF3030FFu;
+
+    // Draw a literal damage number over the actor.
+    public static void Show(SimCharacter target, uint amount, string label)
+    {
+        var bc = target.BattleCharaPtr;
+        if (bc == null) return;
+        var actorIndex = ((GameObject*)bc)->ObjectIndex;
+
+        // Positional args: kind, actorIndex, val1, val2, text1, text2, color, icon, yOffset.
+        // val1 is the number, text1 the label — putting the number in both prints it twice.
+        Plugin.FlyText.AddFlyText(
+            FlyTextKind.Damage,
+            actorIndex,
+            amount,
+            0,
+            new SeString(new TextPayload(label)),
+            new SeString(),
+            DamageColorAbgr,
+            0,
+            0);
+    }
+
+    // Convenience: size the number off the target's own MaxHealth ("X% of max HP").
+    public static void ShowFraction(SimCharacter target, float fractionOfMaxHp, string label)
+    {
+        var bc = target.BattleCharaPtr;
+        if (bc == null) return;
+        Show(target, (uint)MathF.Round(fractionOfMaxHp * bc->MaxHealth), label);
+    }
+}

--- a/AnoMech/Core/SimObjects/SimPlayer.cs
+++ b/AnoMech/Core/SimObjects/SimPlayer.cs
@@ -13,7 +13,8 @@ public sealed unsafe class SimPlayer(Coordinates coordinates) : SimCharacter(coo
     private const ushort StunStatusId = 896;  // "Down for the Count" (896) — IsPermanent + LockControl variant.
 
     // The player's HP bar (real bc->Health) is touched only on a scenario KO — dropped to a 1-HP
-    // sliver here, restored in RestoreHpBar (revive / godmode heal-back). Driven by DamageSolver.
+    // sliver here (from OnKilled on a real death, and from Game.Kill for the godmode preview),
+    // restored in RestoreHpBar (revive / godmode heal-back).
     public void DropHpBar()
     {
         var bc = BattleCharaPtr;
@@ -74,6 +75,7 @@ public sealed unsafe class SimPlayer(Coordinates coordinates) : SimCharacter(coo
     {
         Dead = true;
         StopMoving();
+        DropHpBar(); // real-death bar drop (bots do the same in their own OnKilled); godmode skips this path
         AddStatus(StunStatusId);
         this.PlayKoActionTimeline();
         SyncInputLock(); // engage the lock now, not one frame later
@@ -83,9 +85,11 @@ public sealed unsafe class SimPlayer(Coordinates coordinates) : SimCharacter(coo
     {
         base.Despawn();
         StopMoving();
+        // Undo any KO bar drop (no-op if already full). Unconditional so it also covers a godmode
+        // preview drop, where Dead is never set and a pending heal on Game.Events may be cleared by reset.
+        RestoreHpBar();
         if (Dead)
         {
-            RestoreHpBar(); // undo the KO bar drop (no-op if we never dropped it)
             ResetActionTimeline();
             PlayActionTimeline(77); // revive
             Dead = false;

--- a/AnoMech/Core/SimObjects/SimPlayer.cs
+++ b/AnoMech/Core/SimObjects/SimPlayer.cs
@@ -11,7 +11,21 @@ namespace AnoMech.Core.SimObjects;
 public sealed unsafe class SimPlayer(Coordinates coordinates) : SimCharacter(coordinates), ISimPartyMember
 {
     private const ushort StunStatusId = 896;  // "Down for the Count" (896) — IsPermanent + LockControl variant.
-    
+
+    // The player's HP bar (real bc->Health) is touched only on a scenario KO — dropped to a 1-HP
+    // sliver here, restored in RestoreHpBar (revive / godmode heal-back). Driven by DamageSolver.
+    public void DropHpBar()
+    {
+        var bc = BattleCharaPtr;
+        if (bc != null) bc->Health = 1;
+    }
+
+    public void RestoreHpBar()
+    {
+        var bc = BattleCharaPtr;
+        if (bc != null && bc->Health < bc->MaxHealth) bc->Health = bc->MaxHealth;
+    }
+
     public PartyRole Role { get; set; }
     public bool Dead { get; private set; }
 
@@ -71,6 +85,7 @@ public sealed unsafe class SimPlayer(Coordinates coordinates) : SimCharacter(coo
         StopMoving();
         if (Dead)
         {
+            RestoreHpBar(); // undo the KO bar drop (no-op if we never dropped it)
             ResetActionTimeline();
             PlayActionTimeline(77); // revive
             Dead = false;

--- a/AnoMech/Plugin.cs
+++ b/AnoMech/Plugin.cs
@@ -29,6 +29,7 @@ public sealed class Plugin : IDalamudPlugin
     [PluginService] internal static ISigScanner SigScanner { get; private set; } = null!;
     [PluginService] internal static IGameInteropProvider GameInterop { get; private set; } = null!;
     [PluginService] internal static IChatGui ChatGui { get; private set; } = null!;
+    [PluginService] internal static IFlyTextGui FlyText { get; private set; } = null!;
     [PluginService] internal static IPartyList PartyList { get; private set; } = null!;
     [PluginService] internal static IPluginLog Log { get; private set; } = null!;
     [PluginService] internal static IDutyState DutyState { get; private set; } = null!;

--- a/AnoMech/Scenarios/DamageSolver.cs
+++ b/AnoMech/Scenarios/DamageSolver.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using AnoMech.Core;
 using AnoMech.Core.Game;
 using AnoMech.Core.Game.Party;
+using AnoMech.Core.Native;
 using AnoMech.Core.SimObjects;
 
 namespace AnoMech.Scenarios;
@@ -14,10 +15,14 @@ public class DamageSolver
     private Dictionary<ushort, int> statusStacksOverwrites = [];
 
     SimParty party;
+    private readonly EventScheduler? godmodeHealScheduler;
 
-    public DamageSolver(SimParty party)
+    // godmodeHealScheduler: ApplyDamage uses it to heal a member back after a godmode hit.
+    // Optional — only scenarios that call ApplyDamage pass one (P5 exaflares its timeline).
+    public DamageSolver(SimParty party, EventScheduler? godmodeHealScheduler = null)
     {
         this.party = party;
+        this.godmodeHealScheduler = godmodeHealScheduler;
     }
     
     
@@ -151,6 +156,28 @@ public class DamageSolver
             Plugin.Log.Info($"{(target as ISimPartyMember)?.Role} got lethal damage due to {statusId}");
         }
         return statusId != 0;
+    }
+
+    // Damage feedback: a flytext number sized off the target's own max HP, plus — when the hit
+    // is lethal — the KO via Die() (the same sink as every death). `lethal` is the caller's call
+    // (exaflare = always; spread = only on overlap); `context` is the death-message parenthetical.
+    // Non-party targets ignored. Bots empty their bar via their own OnKilled; the player's HP is
+    // left alone by OnKilled, so its bar is dropped to a sliver here. Godmode never kills but still
+    // shows the number + drop, then heals the player's bar back a beat later.
+    private const float GodmodeHealSeconds = 1.2f;
+    public void ApplyDamage(SimCharacter target, float fractionOfMaxHp, uint actionId, string context, bool lethal)
+    {
+        if (target is not ISimPartyMember) return;
+        var name = ActionLookup.Name(actionId);
+        DamageNumbers.ShowFraction(target, fractionOfMaxHp, name);
+        if (!lethal) return;
+        target.Die($"Died to {name} ({context})");
+        if (target is SimPlayer player)
+        {
+            player.DropHpBar();
+            if (Plugin.GameInstance.GodMode)
+                godmodeHealScheduler?.Add(GodmodeHealSeconds, player.RestoreHpBar);
+        }
     }
 
     public void SetStatuses(DamageType type, params ushort[] statuses)

--- a/AnoMech/Scenarios/DamageSolver.cs
+++ b/AnoMech/Scenarios/DamageSolver.cs
@@ -15,14 +15,10 @@ public class DamageSolver
     private Dictionary<ushort, int> statusStacksOverwrites = [];
 
     SimParty party;
-    private readonly EventScheduler? godmodeHealScheduler;
 
-    // godmodeHealScheduler: ApplyDamage uses it to heal a member back after a godmode hit.
-    // Optional — only scenarios that call ApplyDamage pass one (P5 exaflares its timeline).
-    public DamageSolver(SimParty party, EventScheduler? godmodeHealScheduler = null)
+    public DamageSolver(SimParty party)
     {
         this.party = party;
-        this.godmodeHealScheduler = godmodeHealScheduler;
     }
     
     
@@ -161,10 +157,9 @@ public class DamageSolver
     // Damage feedback: a flytext number sized off the target's own max HP, plus — when the hit
     // is lethal — the KO via Die() (the same sink as every death). `lethal` is the caller's call
     // (exaflare = always; spread = only on overlap); `context` is the death-message parenthetical.
-    // Non-party targets ignored. Bots empty their bar via their own OnKilled; the player's HP is
-    // left alone by OnKilled, so its bar is dropped to a sliver here. Godmode never kills but still
-    // shows the number + drop, then heals the player's bar back a beat later.
-    private const float GodmodeHealSeconds = 1.2f;
+    // Non-party targets ignored. The KO and all HP-bar handling — real-death drop in SimPlayer.OnKilled,
+    // and the godmode drop/heal preview in Game.Kill — live downstream of Die(), so this only shows the
+    // number and forwards the kill.
     public void ApplyDamage(SimCharacter target, float fractionOfMaxHp, uint actionId, string context, bool lethal)
     {
         if (target is not ISimPartyMember) return;
@@ -172,12 +167,6 @@ public class DamageSolver
         DamageNumbers.ShowFraction(target, fractionOfMaxHp, name);
         if (!lethal) return;
         target.Die($"Died to {name} ({context})");
-        if (target is SimPlayer player)
-        {
-            player.DropHpBar();
-            if (Plugin.GameInstance.GodMode)
-                godmodeHealScheduler?.Add(GodmodeHealSeconds, player.RestoreHpBar);
-        }
     }
 
     public void SetStatuses(DamageType type, params ushort[] statuses)

--- a/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresAi.cs
+++ b/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresAi.cs
@@ -1,0 +1,378 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using AnoMech.Core.Game;
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.Game.Party;
+using AnoMech.Core.SimObjects;
+using static AnoMech.Scenarios.Umad.UmadConstants;
+
+namespace AnoMech.Scenarios.Umad.P5Exaflares;
+
+// Bots for UMAD P5 exaflares: the 7 doppels weave the rolling walls, then spread for the final
+// ExaflareSpread (the local player dodges themselves). Scheduled on the scenario's unscaled
+// `timeline`, not the stock AiManager (which rides EventTimeScale), so they stay frame-locked to the
+// fire; spread relaxation runs per-frame from the scenario's Tick via state.SpreadTick.
+//
+// DODGE GEOMETRY. The fire is two perpendicular diagonal families: left line k burns X-Z = -35+10k,
+// right line k burns X+Z = -35+10k. Each wave fires a {1,4}/{2,5}/{3,6} pair, leaving a wide central
+// safe lane (and an outer lane beyond the pair when it's off-centre). A radius-6 fire spans 6*sqrt2 in
+// X±Z space, so the strip inset must clear that, not 6. Lingering fire is safe - only the snapshot kills.
+//
+// DODGE PLACEMENT. Each wave's fire runs along one diagonal axis (crit); the perp axis is where the
+// previous wave's fire is still rolling as this wave lands. So a bot FREEZES its perp coordinate and
+// moves only along crit into a safe lane (PlaceWave): that never crosses the still-firing previous
+// wave, and the frozen perp was already made safe by that wave (which used this axis as its own crit) -
+// safe by induction, no carried band state, no coin flips. Melee/tank pull crit toward the boss for
+// uptime; others hold their spot, and a de-clump pass (DeClump) spreads bunched bots along the crit
+// axis only (never the frozen perp). The opening formation thus carries through the whole fight.
+//
+// SPREAD. Per-frame force-relaxation (RelaxStep): repulsion from every agent within Comfort, a radial
+// spring (inner roles in a melee annulus, outer roles to OuterRing), and arena keep-in.
+//
+// OPENING. Before wave 0's dodge (t~2.0) the doppels fan out from their tight spawn ring into the melee
+// annulus (FanOut): each pushes out along its own ring angle to a random melee radius, so they enter the
+// fight already spread and each solves its first lane from a distinct spot instead of the shared huddle.
+public sealed class UmadP5ExaflaresAi : IScenarioAi<UmadP5ExaflaresState>
+{
+    public string Name => "Spread";
+
+    // --- dodge geometry ---
+    private const float LocusBase = -35f, LocusStep = 10f;       // locus(k) = -35 + 10k
+    private const float FireRadius = 6f;                          // ExaflareHit EffectRange
+    private static readonly float FireClearU = FireRadius * MathF.Sqrt(2f); // ~8.49 in X±Z space
+    private static readonly float StripInset = FireClearU + 1.5f; // keep bots clear of a fired locus
+    private const float OuterReach = 19f;                         // outer-lane reach in X±Z space (arena-bounded)
+    private const float DistFill = 0.8f;                          // keep bots off a lane's edges (extra fire margin)
+    private const float DodgeSpeed = 7f;                          // sprint-ish, so the back-solve makes the snapshot
+
+    // --- dodge placement ---
+    private const float MeleeComfort = 2.5f;                      // melee happily stack this close
+    private const float SpreadComfort = 6f;                       // ranged/healers claim this much room
+    private const float TargetJitter = 0.6f;                      // natural noise per pick (symmetry-break + run variety)
+    private const int   DeClumpIters = 6;
+    private const float DeClumpRate = 0.5f;
+
+    // --- opening fan-out ---
+    private const float FanOutAt = 0.1f;                          // after SpawnKefka (t=0), so the boss radius reads
+    private const float FanSpeed = 6f;                            // settle well before wave 0's dodge at t=2.0
+    private const float FanInnerMargin = 0.75f;                   // inner fan radius = NoGoRadius + this
+    private const float FanAngleJitter = 0.5f;                    // rad, so the wheel isn't rigid (< ring spacing)
+
+    // --- spread relaxation ---
+    private const float SpreadKill = 5f;                          // ExaflareSpread EffectRange (kill radius)
+    private const float Comfort = 9.75f;                          // relaxation target separation (kill 5y + 50% wider spread)
+    private const float OuterRing = 13f;                          // healers / ranged ring
+    private const float InnerFallback = 6.5f;                     // max-melee (inner annulus outer edge) if the boss can't be read
+    private const float NoGoRadius = 3.5f;                        // 7y-diameter hard no-go at the boss
+    private const float ArenaMax = 19f;
+    private const float RelaxSpeed = 6f;
+    private const float DeadZone = 0.25f;                         // below this desired step, leave the bot be
+    private const float WRepel = 1.0f, WArena = 1.5f;
+    // Radial spring weights: inner roles pull harder so the wider spacing doesn't shove tanks/melee
+    // out of melee range; outer roles stay loose so repulsion can spread them.
+    private const float WRadialInner = 0.5f, WRadialOuter = 0.30f;
+
+    // --- exaflare timing (mirrors the scenario) ---
+    private const float FirstHitDelay = 4.582f;
+    private const float BloomDelay = 14f / 30f;
+    private const float ArriveLead = 0.4f;                        // be parked this long before a wave's first snapshot
+    private static readonly float[] WaveStart = { 3.0f, 5.5f, 8.0f, 10.5f, 13.0f, 15.5f };
+
+    private UmadP5ExaflaresState state = null!;
+    private SimWorld world = null!;
+    private EventScheduler timeline = null!;
+    private readonly Random rng = new();
+    private readonly bool[] relaxMoving = new bool[8];
+    private bool spreadPhase;
+    private float innerRing = InnerFallback;
+
+    public void Run(UmadP5ExaflaresState stateParam, SimWorld worldParam)
+    {
+        state = stateParam;
+        world = worldParam;
+        timeline = state.Timeline;
+
+        ScheduleInitialFanOut();
+        for (int n = 0; n < 6; n++) ScheduleWaveDodge(n);
+
+        // Spread phase: opens after wave 6's last snapshot (~22.65), closes at the spread snapshot
+        // (25.09); relaxation runs across that window from the scenario's Tick.
+        timeline.Add(22.75f, () => { spreadPhase = true; innerRing = ResolveInnerRing(); Array.Clear(relaxMoving); });
+        timeline.Add(25.09f, () => spreadPhase = false);
+        state.SpreadTick = RelaxStep;
+    }
+
+    // Schedule wave n's dodge. The whole group is placed at fire-time (PlaceWave), departing so each
+    // arrives before the wave's first snapshot and leaves only after wave n-2 cleared.
+    private void ScheduleWaveDodge(int n)
+    {
+        float startT = WaveStart[n];
+        float firstSnapshot = startT + FirstHitDelay;               // the wave's first eruption/snapshot instant
+        float arriveBy = firstSnapshot - ArriveLead;
+        float safeMove = n == 0 ? 2.0f : startT + 1.7f + BloomDelay; // after wave n-2's last snapshot; n==0: big initial run, no prior fire
+        float budget = arriveBy - safeMove;
+
+        timeline.Add(safeMove, () => PlaceWave(n, budget));
+    }
+
+    // Place the group for wave n. The fire runs along one diagonal axis (crit); the other axis (perp)
+    // is where the previous wave's fire is still rolling. So each bot FREEZES its perp coordinate and
+    // moves only along crit into a safe lane - that never crosses the still-firing previous wave, and
+    // the perp value was already made safe by that wave (which used this axis as its crit). Melee/tank
+    // pull crit toward the boss for uptime; a de-clump pass spreads the rest along the lane. Each
+    // departure is back-solved so the bot holds position until it must leave to make the snapshot.
+    private void PlaceWave(int n, float budget)
+    {
+        bool leftWave = (n % 2) == 0;
+        var lanes = UsableBands(n);                                  // safe crit lanes (central + maybe outer)
+        if (lanes.Count == 0) return;
+        int playerSlot = (int)world.Party.PlayerRole;
+
+        var picks = new List<Pick>(7);
+        for (int slot = 0; slot < 8; slot++)
+        {
+            if (slot == playerSlot) continue;                       // the player dodges themselves
+            var bot = world.Party.Get(slot);
+            if (bot is null || !bot.IsAlive()) continue;
+
+            bool inner = IsInnerRole((PartyRole)slot);
+            var (crit, perp) = ToCritPerp(bot.Position, leftWave);
+            float want = (inner ? 0f : crit) + Jitter();            // melee hug the boss; others hold their spot
+            picks.Add(new Pick(bot, PlaceInLanes(lanes, want), perp, inner));
+        }
+
+        DeClump(picks, lanes);
+
+        foreach (var pk in picks)
+        {
+            var dest = FromCritPerp(pk.Crit, pk.Perp, leftWave);
+            float delay = budget - FlatDist(pk.Bot.Position, dest) / DodgeSpeed; // leave late enough to arrive on time
+            if (delay > 0f) timeline.Add(delay, () => pk.Bot.MoveTo(dest, DodgeSpeed));
+            else pk.Bot.MoveTo(dest, DodgeSpeed);                   // farther than the budget allows: best effort
+        }
+    }
+
+    // Opening fan-out: push each doppel out of the tight spawn ring into the melee annulus before the
+    // first dodge. Each bot keeps its own spawn-ring angle (so the ring's even spread carries over - no
+    // pile-up) and moves out to a random melee radius with a little angular jitter. Run-to-run variety
+    // comes from the spawn jitter plus the random radius/angle here; they settle long before wave 0.
+    private void ScheduleInitialFanOut()
+    {
+        timeline.Add(FanOutAt, () =>
+        {
+            int playerSlot = (int)world.Party.PlayerRole;
+            float outer = ResolveInnerRing();                       // max-melee around the boss
+            float inner = MathF.Min(NoGoRadius + FanInnerMargin, outer - 0.5f);
+
+            for (int slot = 0; slot < 8; slot++)
+            {
+                if (slot == playerSlot) continue;                   // the player isn't ours to move
+                var bot = world.Party.Get(slot);
+                if (bot is null || !bot.IsAlive()) continue;
+
+                var cur = bot.Position;
+                float baseAngle = MathF.Atan2(cur.X, cur.Z);        // its spawn-ring angle (localPos = sin,cos)
+                float angle = baseAngle + ((float)rng.NextDouble() - 0.5f) * FanAngleJitter;
+                float radius = inner + (float)rng.NextDouble() * (outer - inner);
+                var target = new Vector3(MathF.Sin(angle) * radius, 0f, MathF.Cos(angle) * radius);
+                bot.MoveTo(target, FanSpeed);
+            }
+        });
+    }
+
+    // Wave n's usable safe lanes in its crit coordinate: the central lane always, the outer lane when
+    // the fired pair is off-centre. Filled to keep bots off the lane edges.
+    private List<(float lo, float hi)> UsableBands(int n)
+    {
+        var bands = new List<(float lo, float hi)> { Fill(Band(n, 0)) };
+        if (OuterAvailable(n)) bands.Add(Fill(Band(n, 1)));
+        return bands;
+    }
+
+    // Clamp a wanted crit value into the safe lane nearest to it (least travel onto safety). Always
+    // lands inside a lane, so the result is clear of this wave's fire.
+    private static float PlaceInLanes(List<(float lo, float hi)> lanes, float want)
+    {
+        float best = want; float bestD = float.MaxValue;
+        foreach (var (lo, hi) in lanes)
+        {
+            float c = Math.Clamp(want, lo, hi);
+            float d = MathF.Abs(c - want);
+            if (d < bestD) { bestD = d; best = c; }
+        }
+        return best;
+    }
+
+    // Spread bunched targets apart along the crit axis only (perp is frozen - the still-firing wave's
+    // axis - so we never nudge anyone into it). Repulsion uses full 2D separation but moves crit alone;
+    // two melee use a tight comfort (they stack), any pair with an outer role yields its wider spacing.
+    private void DeClump(List<Pick> picks, List<(float lo, float hi)> lanes)
+    {
+        for (int iter = 0; iter < DeClumpIters; iter++)
+            for (int i = 0; i < picks.Count; i++)
+            {
+                var pi = picks[i];
+                float push = 0f;
+                for (int j = 0; j < picks.Count; j++)
+                {
+                    if (j == i) continue;
+                    var pj = picks[j];
+                    float comfort = pi.Inner && pj.Inner ? MeleeComfort : SpreadComfort;
+                    float dc = pi.Crit - pj.Crit, dp = pi.Perp - pj.Perp;
+                    float dist = MathF.Sqrt(dc * dc + dp * dp);
+                    if (dist >= comfort) continue;
+                    float dir = dist > 1e-3f ? dc / dist : MathF.Sign(i - j); // crit component; tie-break by index
+                    push += dir * (comfort - dist);
+                }
+                if (MathF.Abs(push) < 1e-3f) continue;
+                pi.Crit = PlaceInLanes(lanes, pi.Crit + push * DeClumpRate); // re-clamp: stays in a safe lane
+            }
+    }
+
+    private float Jitter() => ((float)rng.NextDouble() - 0.5f) * TargetJitter;
+
+    // Split a world position into the wave's crit/perp diagonal coords. a = X-Z, b = X+Z; the crit axis
+    // is the one this wave's fire runs along (a for a left wave, b for a right wave), perp the other.
+    private static (float crit, float perp) ToCritPerp(Vector3 pos, bool leftWave)
+    {
+        float a = pos.X - pos.Z, b = pos.X + pos.Z;
+        return leftWave ? (a, b) : (b, a);
+    }
+
+    private static Vector3 FromCritPerp(float crit, float perp, bool leftWave)
+    {
+        float a = leftWave ? crit : perp, b = leftWave ? perp : crit;
+        return new Vector3((a + b) * 0.5f, 0f, (b - a) * 0.5f);
+    }
+
+    // A doppel's wave placement: the character, its safe-lane crit target, its frozen perp, and role.
+    private sealed class Pick
+    {
+        public readonly SimCharacter Bot;
+        public float Crit;
+        public readonly float Perp;
+        public readonly bool Inner;
+        public Pick(SimCharacter bot, float crit, float perp, bool inner) { Bot = bot; Crit = crit; Perp = perp; Inner = inner; }
+    }
+
+    private static float FlatDist(Vector3 a, Vector3 b) =>
+        Vector2.Distance(new Vector2(a.X, a.Z), new Vector2(b.X, b.Z));
+
+    // Force-relaxation step, driven every frame from the scenario's Tick during the spread window.
+    // Moves only the doppels; the player is read as a repulsor but never moved.
+    private void RelaxStep(float dt)
+    {
+        if (!spreadPhase) return;
+
+        var agents = new List<(SimCharacter c, Vector2 p)>(8);
+        for (int i = 0; i < 8; i++)
+            if (world.Party.Get(i) is { } m && m.IsAlive())
+                agents.Add((m, new Vector2(m.Position.X, m.Position.Z)));
+
+        int playerSlot = (int)world.Party.PlayerRole;
+        for (int slot = 0; slot < 8; slot++)
+        {
+            if (slot == playerSlot) continue;
+            var bot = world.Party.Get(slot);
+            if (bot is null || !bot.IsAlive()) continue;
+            var p = new Vector2(bot.Position.X, bot.Position.Z);
+
+            var desired = Vector2.Zero;
+
+            // Repulsion from every other agent inside the comfort radius (yield to bots AND player).
+            foreach (var (c, q) in agents)
+            {
+                if (ReferenceEquals(c, bot)) continue;
+                var d = p - q;
+                var dist = d.Length();
+                if (dist >= Comfort) continue;
+                var dir = dist > 1e-3f ? d / dist : Spoke(slot);
+                desired += dir * (Comfort - dist) * WRepel;
+            }
+
+            // Radial shaping: inner roles free in the melee annulus [NoGoRadius..innerRing] (pull in
+            // past it, push out inside the no-go); outer roles soft-sprung to OuterRing.
+            bool inner = IsInnerRole((PartyRole)slot);
+            float r = p.Length();
+            var rdir = r > 1e-3f ? p / r : Spoke(slot);
+            if (inner)
+            {
+                if (r > innerRing) desired += rdir * (innerRing - r) * WRadialInner;        // past max melee: pull in
+                else if (r < NoGoRadius) desired += rdir * (NoGoRadius - r) * WRadialInner; // inside no-go: push out
+            }
+            else
+            {
+                desired += rdir * (OuterRing - r) * WRadialOuter;
+            }
+            if (r > ArenaMax) desired += rdir * (ArenaMax - r) * WArena;
+
+            if (desired.Length() > DeadZone)
+            {
+                var step = desired.Length() > 5f ? desired * (5f / desired.Length()) : desired;
+                var t = p + step;
+                bot.MoveTo(new Vector3(t.X, 0f, t.Y), RelaxSpeed);
+                relaxMoving[slot] = true;
+            }
+            else if (relaxMoving[slot])
+            {
+                bot.MoveTo(new Vector3(p.X, 0f, p.Y), RelaxSpeed); // settle once, then leave it idle (no anim stutter)
+                relaxMoving[slot] = false;
+            }
+        }
+    }
+
+    // Inner ring = max-melee around the boss (fixed at arena centre): live hitbox + 3, floored.
+    private float ResolveInnerRing()
+    {
+        var boss = world.Children.OfType<SimEnemy>()
+                        .FirstOrDefault(e => e.IsAlive() && e.BNpcBaseId == BNpcBaseId.KefkaP5);
+        float hitbox = boss?.HitboxRadius ?? 3.5f;
+        return MathF.Max(hitbox + 3f, 6f);
+    }
+
+    private static bool IsInnerRole(PartyRole r) =>
+        r.IsTank() || r == PartyRole.MeleeDpsA || r == PartyRole.MeleeDpsB;
+
+    // An outer lane is usable only when the fired pair sits off-centre ({1,4} low or {3,6} high); a
+    // centred pair ({2,5}) leaves only thin edge slivers, so those waves stay central-only.
+    private bool OuterAvailable(int n)
+    {
+        var (lo, hi) = PairLoHi(n);
+        return MathF.Abs((lo + hi) * 0.5f) > 1f;
+    }
+
+    // The two fired loci for wave n, sorted, in that wave's crit coordinate.
+    private (float lo, float hi) PairLoHi(int n)
+    {
+        var order = (n % 2) == 0 ? state.LeftOrder : state.RightOrder;
+        int pairBase = (n / 2) * 2;
+        float l1 = Locus(order[pairBase]), l2 = Locus(order[pairBase + 1]);
+        return (MathF.Min(l1, l2), MathF.Max(l1, l2));
+    }
+
+    // A safe band for wave n in its crit coordinate. idx 0 = central lane between the fired loci; idx 1
+    // = outer lane beyond the pair (away from centre). Both inset by StripInset to clear the radius-6 fire.
+    private (float lo, float hi) Band(int n, int idx)
+    {
+        var (lo, hi) = PairLoHi(n);
+        if (idx == 0) return (lo + StripInset, hi - StripInset);          // central lane
+        return (lo + hi) * 0.5f < 0f                                       // outer lane, arena-bounded
+            ? (hi + StripInset, OuterReach)                                // pair sits low -> lane above it
+            : (-OuterReach, lo - StripInset);                             // pair sits high -> lane below it
+    }
+
+    private static float Locus(int lineIdx) => LocusBase + LocusStep * lineIdx;
+
+    // Shrink an interval toward its midpoint, leaving a margin so jitter + lateral scatter can't reach
+    // the fire even at the edges.
+    private static (float lo, float hi) Fill((float lo, float hi) s)
+    {
+        float mid = (s.lo + s.hi) * 0.5f, half = (s.hi - s.lo) * 0.5f * DistFill;
+        return (mid - half, mid + half);
+    }
+
+    // Deterministic unit direction for degenerate cases (co-located agents / a bot dead-centre).
+    private static Vector2 Spoke(int slot) => new(MathF.Cos(slot * 0.785f), MathF.Sin(slot * 0.785f));
+}

--- a/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresScenario.cs
+++ b/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresScenario.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Numerics;
+using AnoMech.Core;
+using AnoMech.Core.Game;
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.Map;
+using AnoMech.Core.SimObjects;
+using static AnoMech.Scenarios.Umad.UmadConstants;
+
+namespace AnoMech.Scenarios.Umad.P5Exaflares;
+
+// UMAD P5 "exaflares" (ground-fire): two diagonal walls of fire roll across the arena, then a
+// final spread. Runs solo or with bots (UmadP5ExaflaresAi).
+//
+// Rolling hits are animation-based (no per-tile marker, just the ExaflareOmen lane arrow): each
+// eruption snapshots position as it goes off and holds the kill one application delay later.
+// Lingering fire is safe - only the snapshot instant kills.
+//
+// The timeline runs on a scenario-local Stopwatch (`timeline`), not the engine's ms-truncated
+// UpdateDelta, so events fire drift-free and ignore the Speed buttons.
+public sealed class UmadP5ExaflaresScenario : IScenario
+{
+    public string Name => "UMAD P5 Exaflares";
+    public TargetInstance TargetInstance { get; } = new(
+        TerritoryId: 1363,
+        Origin: new Vector3(100.000f, 0f, 100.000f),
+        PlayerPosition: new Vector3(100.000f, 0f, 116.000f),
+        WeatherId: 175); // P5 weather (P3-4 used 174)
+    public IReadOnlyList<Waymark> Waymarks { get; } = UmadWaymarks;
+    public IReadOnlyList<WaymarkLayout> WaymarkPresets { get; } = UmadConstants.WaymarkPresets;
+    public ushort Bgm => 20294; // P5 BGM (P3-4 used 20293)
+    public byte Level => 100;
+    public bool SupportsSolo => true;
+    public IReadOnlyList<Vector3> ColliderRemovalPoints => [new(0, 0, -10)];
+
+    public IReadOnlyList<IScenarioAi> AiStrats => [new UmadP5ExaflaresAi()];
+
+    public void DrawSettings() => settingsWindow.Draw();
+    private readonly UmadP5ExaflaresSettingsWindow settingsWindow = new();
+
+    private UmadP5ExaflaresState state = null!;
+    private SimWorld world = null!;
+    private SimParty party = null!;
+    private DamageSolver damage = null!;
+    private SimEnemy? kefka;
+    // One spread helper per player — each member is its own AoE source.
+    private readonly List<SimEnemy> spreadHelpers = new();
+    // One entry per (spread source × member-in-range) application, snapshotted at ResolveSpread
+    // and applied one delay later at ApplySpreadKill. Duplicates are intentional: a member caught
+    // by two spreads (its own + an overlap) appears twice, and two coverings are lethal.
+    private readonly List<SimCharacter> spreadHits = new();
+
+    // Scenario-local clock, advanced by real Stopwatch time so events fire drift-free at 1x.
+    private readonly EventScheduler timeline = new();
+    private readonly Stopwatch wallClock = new();
+    private double lastWall;
+    private const double FrameGapCapSeconds = 0.25; // skip pause / alt-tab / hitch frames
+
+    // Exaflare timing. AoE radii come from the Action sheet's EffectRange (circles), not set here.
+    private const float ExaflareFirstHitDelay = 4.582f; // first rolling hit, after the line launch
+    private const float ExaflareHitInterval   = 0.513f; // between rolling hits
+    private const float ExaflareSourceLead    = 0.62f;  // origin eruption fires this far before hit 1
+    private const int   ExaflareHitCount      = 6;
+    // Visible bloom delay: when the eruption flame peaks (frame 14 @ 30fps). VFX-only — the kill is
+    // not held to this (see ExaflareKillDelay).
+    private const float BloomDelay = 14f / 30f; // 0.467s
+    // Snapshot -> kill application delay (same as the spread's ApplySpreadKill). Sets only the instant
+    // the caught player dies; snapshot, VFX and timeline are unaffected.
+    private const float ExaflareKillDelay = 0.624f;
+    // Full eruption length; keep the VFX helper alive this long so the lingering fire isn't cut.
+    private const float ExaflareVfxDuration = 90f / 30f; // 3.0s
+    // ExaflareOmen (lane arrow) cast time. Visual only — despawned just before completion so its
+    // native release doesn't fire; the source eruption is spawned separately (LaunchExaflareLine).
+    private const float OmenCastTime          = 3.7f;
+    // Despawn the arrow this far before completion to suppress its native release.
+    private const float ArrowReleaseSuppressLead = 0.05f;
+
+    public void Run(SimWorld worldParam, int? selectedAi)
+    {
+        // Resolve RSV names so cast bars read real action names (server-delivered in-duty only; we run
+        // inn-only). The boss casts reuse the Stray Apocalypse / Stray Entropy rows - see UmadConstants.
+        UmadRsvStrings.Seed();
+
+        world = worldParam;
+        party = worldParam.Party;
+        state = new UmadP5ExaflaresState(settingsWindow.Overrides, timeline);
+        damage = new DamageSolver(party, timeline); // ApplyDamage deals % of max HP; godmode heals via the scenario timeline
+        spreadHelpers.Clear();
+
+        // Re-arm the scenario clock for this run (the scenario object is reused).
+        timeline.Clear();
+        wallClock.Restart();
+        lastWall = 0;
+
+        // Bots schedule on the scenario `timeline` (after Clear, so their adds are absolute).
+        if (selectedAi is { } idx && idx < AiStrats.Count)
+            ((IScenarioAi<UmadP5ExaflaresState>)AiStrats[idx]).Run(state, world);
+
+        timeline.Add(1f, InitArena); // set the arena to its P5 state once the zone has settled
+        timeline.Add(0f, SpawnKefka);
+        timeline.Add(3.0f, () => kefka?.Cast(ActionId.ChaosEnd1));
+
+        // Rolling exaflares: left/right pairs every 2.5s, columns from the chosen order.
+        LaunchExaflareLine(3.0f,  state.LeftOrder[0],  isLeft: true);
+        LaunchExaflareLine(3.0f,  state.LeftOrder[1],  isLeft: true);
+        LaunchExaflareLine(5.5f,  state.RightOrder[0], isLeft: false);
+        LaunchExaflareLine(5.5f,  state.RightOrder[1], isLeft: false);
+        LaunchExaflareLine(8.0f,  state.LeftOrder[2],  isLeft: true);
+        LaunchExaflareLine(8.0f,  state.LeftOrder[3],  isLeft: true);
+        LaunchExaflareLine(10.5f, state.RightOrder[2], isLeft: false);
+        LaunchExaflareLine(10.5f, state.RightOrder[3], isLeft: false);
+        LaunchExaflareLine(13.0f, state.LeftOrder[4],  isLeft: true);
+        LaunchExaflareLine(13.0f, state.LeftOrder[5],  isLeft: true);
+        LaunchExaflareLine(15.5f, state.RightOrder[4], isLeft: false);
+        LaunchExaflareLine(15.5f, state.RightOrder[5], isLeft: false);
+
+        timeline.Add(19.2f, () => kefka?.Cast(ActionId.ChaosEnd2, castSeconds: 4.70f)); // 4.70s cast; ends at 23.90
+        timeline.Add(25.09f, ResolveSpread);   // spread VFX + snapshot, cast-end + 1.19s
+        timeline.Add(25.71f, ApplySpreadKill); // held kill on the hit, snapshot + 0.624s
+        timeline.Add(30.0f, DespawnAll);
+    }
+
+    public void Tick(float delta, float elapsed)
+    {
+        // Advance the timeline by real wall time, capping pause/hitch gaps so a freeze can't
+        // fast-forward it. This is what keeps the scenario drift-free.
+        var now = wallClock.Elapsed.TotalSeconds;
+        var wallDelta = now - lastWall;
+        lastWall = now;
+        if (wallDelta > 0 && wallDelta <= FrameGapCapSeconds)
+        {
+            timeline.Tick((float)wallDelta);
+            state?.SpreadTick?.Invoke((float)wallDelta); // bot spread relaxation, also 1x (no-op in solo)
+        }
+    }
+
+    // Set the arena to its P5 state (MapEffect table): 36 SGB slots, base 0x4 with P5 deviations, each
+    // replayed as AddEffect((state<<16)|flags, slot).
+    private void InitArena()
+    {
+        var s = new ushort[0x24];
+        for (var i = 0; i < s.Length; i++) s[i] = 0x4;   // base default (hide/empty)
+        s[0x11] = 0x1; s[0x12] = 0x1;                     // base lit holes
+        s[0x00] = 0x40;                                   // P5
+        s[0x14] = 0x200;                                  // P5 centerpiece ("nine holes")
+        for (var i = 0x15; i <= 0x1C; i++) s[i] = 0x1;    // P5 nine holes
+        for (var i = 0x1D; i <= 0x21; i++) s[i] = 0x2;    // P5 towers of rubble
+
+        for (byte slot = 0; slot < s.Length; slot++)
+        {
+            var state = s[slot];
+            var flags = (byte)(state & 0xFF);
+            if (flags == 0) flags = 0x01;                 // e.g. 0x200: no action bit -> "show"
+            world.Map.AddEffect(((uint)state << 16) | flags, slot);
+        }
+    }
+
+    private void SpawnKefka()
+    {
+        kefka = world.SpawnEnemy(new EnemySpawnConfig(
+            BNpcBaseId: BNpcBaseId.KefkaP5,
+            NameId: BNpcNameId.Kefka,
+            Level: Level,
+            Targetable: true,
+            EnemyList: EnemyListMode.Always,
+            IsVisible: true,
+            Placement: new Placement(Vector3.Zero, MathF.PI)));
+    }
+
+    // One rolling line of fire. `lineIdx` 1-6 faces the source; `isLeft` = top-left wall. The arrow
+    // telegraph appears at launch; the source eruption and rolling hits fire on `timeline`, evenly spaced.
+    private void LaunchExaflareLine(float startT, int lineIdx, bool isLeft)
+    {
+        var initPos = isLeft
+            ? new Vector3(-35f + 5f * lineIdx, 0f, -5f * lineIdx)
+            : new Vector3(5f * lineIdx, 0f, -35f + 5f * lineIdx);
+        var dPos = isLeft ? new Vector3(5f, 0f, 5f) : new Vector3(-5f, 0f, 5f);
+        var heading = MathF.PI * (isLeft ? 1f : -1f) / 4f;
+
+        // Lane telegraph (arrow): visual only. Despawn it just before completion so it doesn't fire
+        // its own eruption - the source is spawned separately below so it lines up with the rolling hits.
+        timeline.Add(startT, () =>
+        {
+            var arrow = SpawnHelper(initPos, heading);
+            arrow?.Cast(ActionId.ExaflareOmen, castSeconds: OmenCastTime);
+            timeline.Add(OmenCastTime - ArrowReleaseSuppressLead, () => arrow?.Despawn());
+        });
+
+        // Source eruption (origin tile): fires ExaflareSourceLead before the first hit. Visual only
+        // (origin is off-arena). Ignites just after the arrow clears.
+        var tEruptSource = startT + ExaflareFirstHitDelay - ExaflareSourceLead;
+        SimEnemy? source = null;
+        timeline.Add(tEruptSource, () =>
+        {
+            source = SpawnHelper(initPos, heading);
+            source?.Cast(ActionId.ExaflareHit, castSeconds: 0f, animationLock: 0f);
+            timeline.Add(ExaflareVfxDuration, () => source?.Despawn());
+        });
+
+        // Rolling hits (one helper per tile). At tErupt the eruption fires its VFX and snapshots
+        // position; the held kill lands at tBloom, one application delay later.
+        for (var i = 0; i < ExaflareHitCount; i++)
+        {
+            var pos = initPos + dPos * (i + 1);
+            var tErupt = startT + ExaflareFirstHitDelay + ExaflareHitInterval * i; // VFX + snapshot
+            var tBloom = tErupt + ExaflareKillDelay;                               // held kill, at damage apply
+
+            SimEnemy? hit = null;
+            IReadOnlyList<SimCharacter> caught = [];
+
+            // Fire the VFX and snapshot together; the kill is held. Despawn after the full eruption.
+            timeline.Add(tErupt, () =>
+            {
+                hit = SpawnHelper(pos, heading);
+                hit?.Cast(ActionId.ExaflareHit, castSeconds: 0f, animationLock: 0f);
+                caught = damage.Resolve(hit, ActionId.ExaflareHit, [DamageType.Lethal], [],
+                    killTargets: false); // snapshot only
+                timeline.Add(ExaflareVfxDuration, () => hit?.Despawn());
+            });
+
+            timeline.Add(tBloom, () => // apply the held damage on the bloom: rolling hit is a 100% one-shot
+            {
+                foreach (var c in caught)
+                    damage.ApplyDamage(c, 1f, ActionId.ExaflareHit, "exaflare snapshot", lethal: true);
+            });
+        }
+    }
+
+    // Final spread (Stray Entropy): each alive member is its own AoE source, and every source hits
+    // everyone within its 5y INCLUDING the caster — so a member is caught by its own spread plus any
+    // overlapping one. A single covering is survivable; two (overlap) is lethal. Snapshot here,
+    // apply one delay later.
+    private void ResolveSpread()
+    {
+        spreadHits.Clear();
+        for (int i = 0; i < 8; i++)
+        {
+            var member = party.Get(i);
+            if (member is null || !member.IsAlive()) continue;
+            var helper = SpawnHelper(member.Position, 0f);
+            if (helper is null) continue;
+            helper.Cast(ActionId.ExaflareSpread); // VFX ignites (the visible burst)
+            spreadHelpers.Add(helper);
+            // [DamageType.Lethal] + killTargets:false selects the in-range set only (no
+            // exclude, so self is included). The 75% is applied by ApplySpreadKill, once
+            // per source covering a member — overlap therefore stacks.
+            var caught = damage.Resolve(helper, ActionId.ExaflareSpread, [DamageType.Lethal], [],
+                killTargets: false);
+            spreadHits.AddRange(caught);
+        }
+    }
+
+    // Held spread application, one delay (0.624s) after the snapshot. spreadHits has one entry per
+    // covering source, so an overlapped member appears twice: show a 75% flytext per covering, and
+    // KO only on overlap (>= 2 coverings) — the last covering carries the kill.
+    private void ApplySpreadKill()
+    {
+        foreach (var grp in spreadHits.GroupBy(c => c))
+        {
+            var count = grp.Count();
+            for (var i = 0; i < count; i++)
+                damage.ApplyDamage(grp.Key, 0.75f, ActionId.ExaflareSpread, "spread snapshot",
+                    lethal: count >= 2 && i == count - 1);
+        }
+        spreadHits.Clear();
+    }
+
+    private SimEnemy? SpawnHelper(Vector3 position, float rotation) =>
+        world.SpawnEnemy(new EnemySpawnConfig(
+            BNpcBaseId: BNpcBaseId.KefkaHelper,
+            NameId: BNpcNameId.Kefka,
+            Level: 1,
+            Targetable: false,
+            EnemyList: EnemyListMode.Never,
+            IsVisible: false,
+            Placement: new Placement(position, rotation)));
+
+    private void DespawnAll()
+    {
+        kefka?.Despawn();
+        foreach (var h in spreadHelpers) h.Despawn();
+        spreadHelpers.Clear();
+    }
+}

--- a/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresScenario.cs
+++ b/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresScenario.cs
@@ -87,7 +87,7 @@ public sealed class UmadP5ExaflaresScenario : IScenario
         world = worldParam;
         party = worldParam.Party;
         state = new UmadP5ExaflaresState(settingsWindow.Overrides, timeline);
-        damage = new DamageSolver(party, timeline); // ApplyDamage deals % of max HP; godmode heals via the scenario timeline
+        damage = new DamageSolver(party); // ApplyDamage deals % of max HP; godmode drop/heal handled in Game.Kill
         spreadHelpers.Clear();
 
         // Re-arm the scenario clock for this run (the scenario object is reused).

--- a/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresSettingsWindow.cs
+++ b/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresSettingsWindow.cs
@@ -1,0 +1,48 @@
+using System;
+using Dalamud.Bindings.ImGui;
+
+namespace AnoMech.Scenarios.Umad.P5Exaflares;
+
+// Settings panel for the P5 exaflares scenario: pick or randomize each side's column order.
+// Mirrors TopP5DeltaSettingsWindow (SettingsGrid two-column layout, "Auto" reset).
+public sealed class UmadP5ExaflaresSettingsWindow
+{
+    public UmadP5ExaflaresStateOverrides Overrides { get; } = new();
+
+    // Index-aligned with the ExaFlareOrder enum (Random = 0, then the six fixed orders).
+    private static readonly string[] OrderLabels =
+    [
+        "Random",
+        "1/4 - 2/5 - 3/6",
+        "1/4 - 3/6 - 2/5",
+        "2/5 - 1/4 - 3/6",
+        "2/5 - 3/6 - 1/4",
+        "3/6 - 1/4 - 2/5",
+        "3/6 - 2/5 - 1/4",
+    ];
+
+    public void Draw()
+    {
+        if (ImGui.Button("Auto"))
+        {
+            Overrides.LeftOrder = ExaFlareOrder.Random;
+            Overrides.RightOrder = ExaFlareOrder.Random;
+        }
+
+        if (SettingsGrid.Begin("##p5exaflares"))
+        {
+            DrawOrderRow("Left order:", "##leftorder", Overrides.LeftOrder, v => Overrides.LeftOrder = v);
+            DrawOrderRow("Right order:", "##rightorder", Overrides.RightOrder, v => Overrides.RightOrder = v);
+            SettingsGrid.End();
+        }
+    }
+
+    private static void DrawOrderRow(string label, string id, ExaFlareOrder current, Action<ExaFlareOrder> set)
+    {
+        SettingsGrid.Row(label);
+        var idx = (int)current;
+        ImGui.SetNextItemWidth(180);
+        if (ImGui.Combo(id, ref idx, OrderLabels, OrderLabels.Length))
+            set((ExaFlareOrder)idx);
+    }
+}

--- a/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresState.cs
+++ b/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresState.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using AnoMech.Core.Game;
+
+namespace AnoMech.Scenarios.Umad.P5Exaflares;
+
+// Per-run randomization: resolves each side's ExaFlareOrder into a concrete length-6 list of line
+// indices (1-6) in launch order - the three waves fire pairs ([0],[1]) then ([2],[3]) then ([4],[5]).
+public sealed class UmadP5ExaflaresState
+{
+    public IReadOnlyList<int> LeftOrder { get; }
+    public IReadOnlyList<int> RightOrder { get; }
+
+    // Handoff to the bot strat. `Timeline` is the scenario's unscaled clock (bots schedule dodges on
+    // it, not the EventTimeScale-scaled AiManager, so they stay frame-locked). `SpreadTick` is the
+    // per-frame relaxation step the strat registers; the scenario's Tick drives it. Both unused in solo.
+    public EventScheduler Timeline { get; }
+    public Action<float>? SpreadTick { get; set; }
+
+    private readonly Rng rng = new();
+
+    public UmadP5ExaflaresState(UmadP5ExaflaresStateOverrides overrides, EventScheduler timeline)
+    {
+        Timeline = timeline;
+        LeftOrder = Resolve(overrides.LeftOrder);
+        RightOrder = Resolve(overrides.RightOrder);
+    }
+
+    private IReadOnlyList<int> Resolve(ExaFlareOrder order)
+    {
+        if (order == ExaFlareOrder.Random)
+            order = rng.NextObj(
+                ExaFlareOrder.Line14_25_36, ExaFlareOrder.Line14_36_25,
+                ExaFlareOrder.Line25_14_36, ExaFlareOrder.Line25_36_14,
+                ExaFlareOrder.Line36_14_25, ExaFlareOrder.Line36_25_14);
+
+        return order switch
+        {
+            ExaFlareOrder.Line14_25_36 => [1, 4, 2, 5, 3, 6],
+            ExaFlareOrder.Line14_36_25 => [1, 4, 3, 6, 2, 5],
+            ExaFlareOrder.Line25_14_36 => [2, 5, 1, 4, 3, 6],
+            ExaFlareOrder.Line25_36_14 => [2, 5, 3, 6, 1, 4],
+            ExaFlareOrder.Line36_14_25 => [3, 6, 1, 4, 2, 5],
+            ExaFlareOrder.Line36_25_14 => [3, 6, 2, 5, 1, 4],
+            _ => [1, 4, 2, 5, 3, 6],
+        };
+    }
+}

--- a/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresStateOverrides.cs
+++ b/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresStateOverrides.cs
@@ -1,0 +1,24 @@
+namespace AnoMech.Scenarios.Umad.P5Exaflares;
+
+// Column order for one side's three exaflare waves. Lines are numbered 1-6 facing the
+// fire source; each wave fires a pair (1/4, 2/5, or 3/6). Random resolves to one of the
+// six fixed orders at scenario start.
+public enum ExaFlareOrder
+{
+    Random,
+    Line14_25_36,
+    Line14_36_25,
+    Line25_14_36,
+    Line25_36_14,
+    Line36_14_25,
+    Line36_25_14,
+}
+
+// User-controlled overrides for UmadP5ExaflaresState's randomized fields. Bound by the
+// scenario's settings UI; Random leaves the field randomized at scenario start. The state
+// ctor consumes this directly. Same shape as TopP5DeltaStateOverrides.
+public sealed class UmadP5ExaflaresStateOverrides
+{
+    public ExaFlareOrder LeftOrder { get; set; } = ExaFlareOrder.Random;
+    public ExaFlareOrder RightOrder { get; set; } = ExaFlareOrder.Random;
+}

--- a/AnoMech/Scenarios/Umad/UmadConstants.cs
+++ b/AnoMech/Scenarios/Umad/UmadConstants.cs
@@ -22,6 +22,7 @@ public static class UmadConstants
         public const uint ChaosP3     = 19508; // distinct row from Chaos 19507
         public const uint Exdeath     = 19509; // cf. NeoExdeath 19510
         public const uint NeoExdeath  = 19510;
+        public const uint KefkaP5     = 19511; // P5 exaflares boss (Simulant spawns 19511 / name 7131)
         public const uint BlackHole   = 19512;
         public const uint KefkaClone  = 19513;
     }
@@ -112,6 +113,11 @@ public static class UmadConstants
         public const uint StrayFlames_Donut            = 0xBB23U; // donut inner r=6, cast 5.0s
         public const uint StraySpray_Donut             = 0xBB24U; // donut inner r=6, cast 5.0s
         public const uint StraySpray_Chariot           = 0xBB25U; // circle r=6, cast 5.0s
+        public const uint ChaosEnd1                    = 0xBB3BU; // P5 body cast (Chaos End), launches the first exaflare set
+        public const uint ExaflareOmen                 = 0xBB3CU; // P5 exaflare line telegraph (omen only, no damage)
+        public const uint ExaflareHit                  = 0xBB3DU; // P5 exaflare explosion, circle r~6; snapshot resolves on this
+        public const uint ChaosEnd2                    = 0xBB3EU; // P5 second body cast
+        public const uint ExaflareSpread               = 0xBB3FU; // P5 final spread, circle r~5
         public const uint BlackSpark                   = 0xBCCDU; // single-target, instant
         public const uint WhiteHole                    = 0xBD66U; // circle r=80, cast 5.0s
         public const uint UltimaUpsurge                = 0xC24AU; // circle r=100, cast 5.0s


### PR DESCRIPTION
Adds the UMAD P5 "Exaflares" scenario

* Kefka spawns, throws out Stray Apocalypse, and then the exaflares kick off and end with the final spread.
* Each Exaflare snapshots where you're standing at cast time (0.467s ahead of the animation) and holds the kill for a moment. Dodging inside the animation feels good, and getting clipped looks and feels like bs, as it should.
* The whole timeline is anchored to actual log data + the real VFX bloom frames.
* The final spread: one on you is survivable, an overlap kills you.
* Patterns are randomized each run. If you want to drill a specific one, there are options inside the settings panel to pin the left/right order.

Bots:

* The 7 bots dodge Exaflares and then spread at the end. They'll try to actively dodge the player and make space, but chasing them won't prevent the overlap :(

Hit feedback:

* When something catches you or a bot, FlyText pops off and the HP bar drops on a lethal hit. It's just a clear "yep, you ate that" read, not real damage math (it's either a KO or nothing).
* Godmode still shows FlyText + the HP bar drop so you can see what would've killed you, then heals you back and you carry on.

Heads up on the boss model:

* The P5 Kefka model comes up invisible. It's not the draw gate (draw enables fine, the object builds), the m1005 model slot just loads empty until it's been cached once (going into the real instance and starting the sim right after will load the model correctly). But it's not blocking practice.