### PR TITLE
Add DMU P5 Celestriad scenario

### DIFF
--- a/AnoMech/Core/Game/Game.cs
+++ b/AnoMech/Core/Game/Game.cs
@@ -16,6 +16,7 @@ using AnoMech.Scenarios.Umad;
 using AnoMech.Scenarios.Umad.P2Forsaken;
 using AnoMech.Scenarios.Umad.P3BlackHole;
 using AnoMech.Scenarios.Umad.P4KefkaSays;
+using AnoMech.Scenarios.Umad.P5Celestriad;
 using AnoMech.Scenarios.Umad.P5Exaflares;
 using AnoMech.Scenarios.Uwu.UltimatePredation;
 using Dalamud.Game.Text;
@@ -76,6 +77,7 @@ public sealed class Game : IDisposable
             new UmadP3BlackHoleScenario(),
             new UmadP4KefkaSaysScenario(),
             new UmadP5ExaflaresScenario(),
+            new UmadP5CelestriadScenario(),
             new UmadP5ForsakenNull(),
             new TopP2PartySynergyScenario(),
             new TopP5DeltaScenario(),

--- a/AnoMech/Core/SimObjects/SimEventObject.cs
+++ b/AnoMech/Core/SimObjects/SimEventObject.cs
@@ -102,6 +102,7 @@ public unsafe class SimEventObject : ISimObject, IPositioned
     public string DisplayName => $"EObj 0x{EObjRowId:X}";
     public int Slot => slot;
     public nint Address => (nint)obj;
+    public GameObjectId GameObjectId => obj == null ? default : obj->GetGameObjectId();
 
     public bool IsAlive => slot >= 0 && obj != null;
     // No death-vs-presence distinction for event objects: kept while the slot is live.

--- a/AnoMech/Core/SimObjects/SimWorld.cs
+++ b/AnoMech/Core/SimObjects/SimWorld.cs
@@ -133,6 +133,13 @@ public sealed class SimWorld : ISimObject, IDisposable
     public void SpawnOmen(string path, Placement placement, Vector3 scale, float durationSeconds)
         => children.Add(new SimOmen(Coordinates, path, placement, scale, durationSeconds));
 
+    // Standalone telegraph derived from `actionId`'s own Omen sheet entry (shape/scale
+    // read from Action.CastType/EffectRange/XAxisModifier), for a boss ability whose real
+    // telegraph is duty-scripted rather than driven by the caster's own cast. SimCast
+    // bypasses Character::StartCast, so the native auto-omen never fires on its own.
+    public void SpawnActionOmen(uint actionId, Vector3 origin, float rotation, float durationSeconds)
+        => children.Add(new SimOmen(Coordinates, actionId, origin, rotation, durationSeconds));
+
     // Change the active weather mid-scenario. weatherId is a Weather-sheet row;
     // transition is the fade-in time in seconds. A scenario's default weather
     // (TargetInstance.WeatherId) is re-applied automatically on restart, so any

--- a/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadAi.cs
+++ b/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadAi.cs
@@ -1,17 +1,22 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using AnoMech.Core.Game.Ai;
+using AnoMech.Core.Game.Party;
 using AnoMech.Core.SimObjects;
 using static AnoMech.Scenarios.Umad.P5Celestriad.UmadP5CelestriadConstants;
 
 namespace AnoMech.Scenarios.Umad.P5Celestriad;
 
 // First-pass bots for Celestriad: each doppel already "knows" its own permanent element (or
-// free-pair role) from state and just runs to that set's matching tower, splitting the pair
-// 1y either side of the tower's tangent so both fit inside the soak radius. On Catastrophic
-// Choice sets (0 and 2), bots first stack in the tower's centre (no inner/outer read yet, the
-// telegraph hasn't happened) and only step to the safe half a second after the cast starts:
-// Aero (green) -> away from the boss, Earth (brown) -> toward the boss.
+// free-pair role) and, within a doubled element's active pair, which tower is "theirs" (see
+// PlaceSet), a strategy call this AI owns, not something UmadP5CelestriadState hands it. Runs
+// to that set's matching tower, splitting the pair 1y either side of the tower's tangent so
+// both fit inside the soak radius. On Catastrophic Choice sets (0 and 2), bots first stack in
+// the tower's centre, then after ChoiceReadDelay step to the safe half: Aero (green) -> away
+// from the boss, Earth (brown) -> toward the boss. This is simulated recognition time, not a
+// read of the ground VFX (which only flashes at resolution, see
+// UmadP5CelestriadScenario.SpawnChoiceOmen): bots already know their side from state directly.
 public sealed class UmadP5CelestriadAi : IScenarioAi<UmadP5CelestriadState>
 {
     public string Name => "Standard";
@@ -23,7 +28,7 @@ public sealed class UmadP5CelestriadAi : IScenarioAi<UmadP5CelestriadState>
     // bot is already standing on the spot when it activates, which reads as the tower spawning
     // under a player instead of on open ground.
     private const float MoveDelay = 1.5f;
-    // How long after Catastrophic Choice's cast starts bots read the telegraph and reposition.
+    // How long after Catastrophic Choice's cast starts bots reposition to their safe half.
     private const float ChoiceReadDelay = 2f;
 
     public void Run(UmadP5CelestriadState state, SimWorld world)
@@ -46,24 +51,39 @@ public sealed class UmadP5CelestriadAi : IScenarioAi<UmadP5CelestriadState>
     private static void PlaceSet(SimWorld world, UmadP5CelestriadState state, int set, int playerSlot, float half)
     {
         var party = world.Party;
-        foreach (var active in state.SetActiveTowers[set])
+        var freeRoles = state.PlayerDebuffElement.Where(kv => kv.Value is null).Select(kv => kv.Key).ToArray();
+
+        // Grouped by element to recover the doubled-pair ordering State guarantees (ascending
+        // sub-index): within a doubled element's 2 active towers, the first always gets that
+        // set's debuffed pair for this element and the second always gets the free pair. This
+        // pairing is this AI's own strategy choice, not a fact State hands us.
+        foreach (var group in state.SetActiveTowers[set].GroupBy(t => t.Element))
         {
-            var tower = active.Tower;
-            var roles = state.AssignedRoles(active, set).ToArray();
+            var debuffedRoles = state.PlayerDebuffElement
+                .Where(kv => kv.Value is not null && state.ElementForSet(kv.Key, set) == group.Key)
+                .Select(kv => kv.Key)
+                .ToArray();
 
-            var inward = Vector3.Normalize(-tower.Position);
-            var lateral = new Vector3(-inward.Z, 0f, inward.X);
+            var towers = group.ToArray();
+            for (var i = 0; i < towers.Length; i++)
+                PlaceAtTower(party, towers[i], i == 0 ? debuffedRoles : freeRoles, playerSlot, half);
+        }
+    }
 
-            for (var i = 0; i < roles.Length; i++)
-            {
-                if ((int)roles[i] == playerSlot) continue;
-                var bot = party.Get(roles[i]);
-                if (bot is null || !bot.IsAlive()) continue;
+    private static void PlaceAtTower(SimParty party, CelestriadTower tower, IReadOnlyList<PartyRole> roles, int playerSlot, float half)
+    {
+        var inward = Vector3.Normalize(-tower.Position);
+        var lateral = new Vector3(-inward.Z, 0f, inward.X);
 
-                var side = i == 0 ? -1f : 1f;
-                var dest = tower.Position + lateral * (side * PairOffset) + inward * (half * HalfOffset);
-                bot.MoveTo(dest, MoveSpeed);
-            }
+        for (var i = 0; i < roles.Count; i++)
+        {
+            if ((int)roles[i] == playerSlot) continue;
+            var bot = party.Get(roles[i]);
+            if (bot is null || !bot.IsAlive()) continue;
+
+            var side = i == 0 ? -1f : 1f;
+            var dest = tower.Position + lateral * (side * PairOffset) + inward * (half * HalfOffset);
+            bot.MoveTo(dest, MoveSpeed);
         }
     }
 }

--- a/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadAi.cs
+++ b/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadAi.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using System.Numerics;
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.SimObjects;
+using static AnoMech.Scenarios.Umad.P5Celestriad.UmadP5CelestriadConstants;
+
+namespace AnoMech.Scenarios.Umad.P5Celestriad;
+
+// First-pass bots for Celestriad: each doppel already "knows" its own permanent element (or
+// free-pair role) from state and just runs to that set's matching tower, splitting the pair
+// 1y either side of the tower's tangent so both fit inside the soak radius. On Catastrophic
+// Choice sets (0 and 2), bots first stack in the tower's centre (no inner/outer read yet, the
+// telegraph hasn't happened) and only step to the safe half a second after the cast starts:
+// Aero (green) -> away from the boss, Earth (brown) -> toward the boss.
+public sealed class UmadP5CelestriadAi : IScenarioAi<UmadP5CelestriadState>
+{
+    public string Name => "Standard";
+
+    private const float MoveSpeed = 6f;
+    private const float PairOffset = 1f;
+    private const float HalfOffset = 2f;
+    // Wait until a tower is actually lit before sending anyone toward it. Moving early means a
+    // bot is already standing on the spot when it activates, which reads as the tower spawning
+    // under a player instead of on open ground.
+    private const float MoveDelay = 1.5f;
+    // How long after Catastrophic Choice's cast starts bots read the telegraph and reposition.
+    private const float ChoiceReadDelay = 2f;
+
+    public void Run(UmadP5CelestriadState state, SimWorld world)
+    {
+        var party = world.Party;
+        var playerSlot = (int)party.PlayerRole;
+
+        for (var set = 0; set < 3; set++)
+        {
+            var s = set;
+            world.Events.Add(CelestriadTiming.TowerStart[s] + MoveDelay, () => PlaceSet(world, state, s, playerSlot, half: 0f));
+            if (CelestriadTiming.CcAt[s] is { } cc)
+                world.Events.Add(cc + ChoiceReadDelay, () => PlaceSet(world, state, s, playerSlot, HalfFor(state, s)));
+        }
+    }
+
+    private static float HalfFor(UmadP5CelestriadState state, int set) =>
+        state.AeroVariant[set] is { } aero ? (aero ? -1f : 1f) : 0f;
+
+    private static void PlaceSet(SimWorld world, UmadP5CelestriadState state, int set, int playerSlot, float half)
+    {
+        var party = world.Party;
+        foreach (var active in state.SetActiveTowers[set])
+        {
+            var tower = active.Tower;
+            var roles = state.AssignedRoles(active, set).ToArray();
+
+            var inward = Vector3.Normalize(-tower.Position);
+            var lateral = new Vector3(-inward.Z, 0f, inward.X);
+
+            for (var i = 0; i < roles.Length; i++)
+            {
+                if ((int)roles[i] == playerSlot) continue;
+                var bot = party.Get(roles[i]);
+                if (bot is null || !bot.IsAlive()) continue;
+
+                var side = i == 0 ? -1f : 1f;
+                var dest = tower.Position + lateral * (side * PairOffset) + inward * (half * HalfOffset);
+                bot.MoveTo(dest, MoveSpeed);
+            }
+        }
+    }
+}

--- a/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadConstants.cs
+++ b/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadConstants.cs
@@ -1,0 +1,87 @@
+namespace AnoMech.Scenarios.Umad.P5Celestriad;
+
+// IDs and tunables for Celestriad. Sourced from Network_30207_20260811.log (pull #16,
+// territory 1363, via tools/parser.py ... 1363 16 <window> -x), the deepest replay-confirmed
+// Celestriad attempt available; ESTIMATE markers below flag values that pull never reached.
+//
+// Non-obvious structural facts:
+// - FireIII/BlizzardIII/ThunderIII are single-target casts (Kefka onto a specific player), not
+//   ground telegraphs. Reused here for both the initial debuff (silent, no cast) and the tower
+//   resolve VFX (cast onto an invisible marker at the tower, so it animates).
+// - The towers are native EventObjects, not cast omens: confirmed via the replay's spawn
+//   packets at radius 10 from arena centre, 40 degrees apart, in three contiguous per-element
+//   blocks (not interleaved): 20/60/100, 140/180/220, 260/300/340 degrees.
+// - All 9 towers spawn once and persist for the whole mechanic; each set just toggles its 4
+//   active towers between DormantState (resting look, ring included) and ActiveState (lit).
+// - Only two Catastrophic Choice casts happen in total, not one per set: the first governs set
+//   0's resolution, the second governs set 2's; set 1 has none and resolves independently
+//   between them.
+// - Aero (green) is safe away from the boss; Earth (brown) is safe toward the boss.
+//
+// Still unverified: which raw action id (CatastrophicChoiceAero/Earth) is actually the green
+// vs. the brown telegraph.
+//
+// Nested types are prefixed Celestriad* (not the usual bare ActionId/StatusId) so this file's
+// `using static` can coexist with UmadConstants': both would otherwise declare a same-named
+// nested class, which is ambiguous under two simultaneous `using static` imports.
+public static class UmadP5CelestriadConstants
+{
+    public static class CelestriadActionId
+    {
+        public const uint Celestriad = 0xBB42U;
+        public const uint CatastrophicChoiceAero = 0xC24EU;  // green, safe half is toward centre
+        public const uint CatastrophicChoiceEarth = 0xC24FU; // brown, safe half is away from centre
+        public const uint FireIII = 0xBB43U;
+        public const uint BlizzardIII = 0xBB44U;
+        public const uint ThunderIII = 0xBB45U;
+    }
+
+    // LightningResistanceDownII and DamageDown are already in the shared UmadConstants.StatusId
+    // (same values); only Fire/Ice need a home here.
+    public static class CelestriadStatusId
+    {
+        public const ushort FireResistanceDownII = 0xB56;
+        public const ushort IceResistanceDownII = 0xB57;
+    }
+
+    // Real EObj rows for the 9 tower props, element mapping confirmed in-game.
+    public static class CelestriadTowerEObjId
+    {
+        public const uint Fire = 0x1EC03EU;
+        public const uint Lightning = 0x1EC040U;
+        public const uint Ice = 0x1EC03FU;
+
+        // SG states for this EObj family, confirmed for all 3 rows.
+        public const ushort ActiveState = 16;
+        public const ushort DormantState = 2;
+    }
+
+    public static class CelestriadGeometry
+    {
+        public const float RingRadius = 10f; // confirmed
+        public const float SoakRadius = 3f;  // ESTIMATE, adjacent same-element towers are 6.84y apart
+    }
+
+    public static class CelestriadTiming
+    {
+        public const float CelestriadCastAt = 1f;
+        public const float CelestriadCastTime = 4.7f;         // confirmed
+        public const float DebuffApplyAt = 6.1f;
+        public const float DebuffDuration = 20f;               // confirmed
+        public const float CatastrophicChoiceCastTime = 4.0f;  // confirmed
+        public const float DamageDownDuration = 30f;           // ESTIMATE
+        public const float TowerDespawnBuffer = 3f;             // ESTIMATE, gap after DeactivateAt[2] before the towers vanish
+
+        // Per-set absolute timestamps (scenario-start-relative). TowerStart[0] (Celestriad
+        // cast-end + 0.4s) is when all 9 towers first spawn (dormant) and also when set 0's 4
+        // activate; TowerStart[1]/[2] activate that set's 4 on the already-spawned towers.
+        // CcAt[0]/[2] (confirmed) are each set's single Catastrophic Choice; ResolveAt[0]/[2]
+        // equal CcAt + CatastrophicChoiceCastTime, so the CC1-end to CC2-end window is a
+        // confirmed fixed 12.16s that has to contain all of set 1. Set 1's own timing splits
+        // that budget close to evenly (an estimate, not replay-confirmed).
+        public static readonly float[] TowerStart = { 6.1f, 14.4f, 20.6f };
+        public static readonly float?[] CcAt = { 10.18f, null, 22.34f };
+        public static readonly float[] ResolveAt = { 14.18f, 20.5f, 26.34f };
+        public static readonly float[] DeactivateAt = { 14.3f, 20.6f, 26.44f };
+    }
+}

--- a/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadScenario.cs
+++ b/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadScenario.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using AnoMech.Core.Game;
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.SimObjects;
+using static AnoMech.Scenarios.Umad.UmadConstants;
+using static AnoMech.Scenarios.Umad.P5Celestriad.UmadP5CelestriadConstants;
+
+namespace AnoMech.Scenarios.Umad.P5Celestriad;
+
+// UMAD P5 "Celestriad": all 9 towers (3 each of Fire/Ice/Lightning) spawn once and stay for the
+// whole mechanic; each of the 3 sets lights up 4 of them (2 single-element towers plus a doubled
+// element's 2). Each party member is permanently debuffed with an element (two each) or left
+// "free" (two more). A debuffed player's actual soak target cycles through all 3 elements across
+// the 3 sets (UmadP5CelestriadState.ElementForSet), never their debuff element until the final
+// set, so nobody soaks the same element twice. Free players always fill the doubled element's
+// second active tower. Sets 0 and 2 (the 1st and 3rd soaks) each get a single Catastrophic
+// Choice cast while their towers are lit, and that set resolves exactly when the cast completes;
+// set 1 has no Catastrophic Choice and resolves independently in between.
+//
+// See UmadP5CelestriadConstants for what's replay-confirmed vs. still an estimate.
+public sealed class UmadP5CelestriadScenario : IScenario
+{
+    public string Name => "Celestriad";
+    public IPhase Phase => UmadZone.P5;
+    public bool SupportsSolo => true;
+
+    public IReadOnlyList<IScenarioAi> AiStrats => [new UmadP5CelestriadAi()];
+
+    public void DrawSettings() => settingsWindow.Draw();
+    private readonly UmadP5CelestriadSettingsWindow settingsWindow = new();
+
+    private UmadP5CelestriadState state = null!;
+    private SimWorld world = null!;
+    private SimParty party = null!;
+    private SimEnemy? kefka;
+    private readonly Dictionary<(CelestriadElement, int), SimEventObject> towerObjects = new();
+    private readonly Dictionary<(CelestriadElement, int), SimEventObject> activeOverlays = new();
+    private readonly Dictionary<(CelestriadElement, int), SimEnemy> towerMarkers = new();
+
+    public void Run(SimWorld worldParam, int? selectedAi)
+    {
+        world = worldParam;
+        party = worldParam.Party;
+        state = new UmadP5CelestriadState(party, settingsWindow.Overrides);
+        towerObjects.Clear();
+        activeOverlays.Clear();
+        towerMarkers.Clear();
+
+        if (selectedAi is { } idx && idx < AiStrats.Count)
+            ((IScenarioAi<UmadP5CelestriadState>)AiStrats[idx]).Run(state, world);
+
+        world.Events.Add(0f, SpawnKefka);
+        world.Events.Add(CelestriadTiming.CelestriadCastAt,
+            () => kefka?.Cast(CelestriadActionId.Celestriad, castSeconds: CelestriadTiming.CelestriadCastTime));
+        world.Events.Add(CelestriadTiming.DebuffApplyAt, ApplyDebuffs);
+        world.Events.Add(CelestriadTiming.TowerStart[0], SpawnAllTowers);
+
+        for (var set = 0; set < 3; set++)
+        {
+            var s = set;
+            world.Events.Add(CelestriadTiming.TowerStart[s], () => ActivateTowers(s));
+            if (CelestriadTiming.CcAt[s] is { } cc) world.Events.Add(cc, () => LaunchChoice(s));
+            world.Events.Add(CelestriadTiming.ResolveAt[s], () => ResolveSet(s));
+            world.Events.Add(CelestriadTiming.DeactivateAt[s], () => DeactivateTowers(s));
+        }
+
+        var teardownAt = CelestriadTiming.DeactivateAt[2] + CelestriadTiming.TowerDespawnBuffer;
+        world.Events.Add(teardownAt, DespawnAllTowers);
+        world.Events.Add(teardownAt, () => kefka?.Despawn());
+    }
+
+    public void Tick(float delta, float elapsed) { }
+
+    private void SpawnKefka()
+    {
+        kefka = world.SpawnEnemy(new EnemySpawnConfig(
+            BNpcBaseId: BNpcBaseId.KefkaP5,
+            NameId: BNpcNameId.Kefka,
+            Level: 100,
+            Targetable: true,
+            EnemyList: EnemyListMode.Always,
+            IsVisible: true,
+            Placement: new Placement(Vector3.Zero, MathF.PI)));
+    }
+
+    // Silent: no cast or animation on the player when the initial debuff lands, just the status.
+    private void ApplyDebuffs()
+    {
+        foreach (var (role, element) in state.PlayerDebuffElement)
+        {
+            if (element is not { } e) continue;
+            party.Get(role)?.AddStatus(ElementDebuff(e), CelestriadTiming.DebuffDuration);
+        }
+    }
+
+    // One cast per applicable set; that set resolves exactly when this cast completes. The
+    // green donut / black circle is duty-scripted decoration in retail, not part of the
+    // action's own release animation, so it needs its own telegraph spawn (matching
+    // TopUtils.ResolveOpticalLaser's pattern for the same kind of scripted-visual gap) rather
+    // than relying on the cast to produce it.
+    private void LaunchChoice(int set)
+    {
+        if (state.AeroVariant[set] is not { } aero || kefka is null) return;
+        var actionId = aero ? CelestriadActionId.CatastrophicChoiceAero : CelestriadActionId.CatastrophicChoiceEarth;
+        kefka.Cast(actionId, castSeconds: CelestriadTiming.CatastrophicChoiceCastTime);
+        world.SpawnActionOmen(actionId, Vector3.Zero, kefka.Rotation, CelestriadTiming.CatastrophicChoiceCastTime);
+    }
+
+    // Real tower props (EObjId per UmadP5CelestriadConstants), not a cast/omen. All 9 spawn once
+    // at DormantState and are never touched again, so they can never flicker. "Activating" a
+    // tower spawns a second, independent EObj at ActiveState layered on the same spot; the
+    // underlying dormant tower stays exactly as it was underneath. Re-attaching a single EObj's
+    // SG state in place (the original approach) caused a visible flicker on every transition;
+    // spawning/despawning a fresh instance doesn't.
+    //
+    // Alongside each tower, spawn its invisible resolve-target marker (see PlayResolveEffect)
+    // right away too and keep it alive for the whole mechanic. Despawning a marker within the
+    // same tick its cast fires cuts the release VFX off before it renders (this is what a
+    // per-resolve spawn/despawn was doing, since DeactivateTowers follows ResolveSet by only
+    // ~0.1s), so the marker's lifetime has to be fully decoupled from any single set's resolve.
+    private void SpawnAllTowers()
+    {
+        foreach (var tower in state.AllTowers)
+        {
+            var key = (tower.Element, tower.SubIndex);
+            var eobj = world.SpawnEventObject(new EventObjectSpawnConfig
+            {
+                EObjId = TowerEObjId(tower.Element),
+                Placement = new Placement(tower.Position, 0f),
+                TimelineState = CelestriadTowerEObjId.DormantState,
+            });
+            if (eobj is not null) towerObjects[key] = eobj;
+
+            var marker = world.SpawnEnemy(new EnemySpawnConfig(
+                BNpcBaseId: BNpcBaseId.KefkaHelper,
+                NameId: BNpcNameId.Kefka,
+                Level: 1,
+                Targetable: false,
+                EnemyList: EnemyListMode.Never,
+                IsVisible: false,
+                Placement: new Placement(tower.Position, 0f)));
+            if (marker is not null) towerMarkers[key] = marker;
+        }
+    }
+
+    private void ActivateTowers(int set)
+    {
+        foreach (var active in state.SetActiveTowers[set])
+        {
+            var key = (active.Tower.Element, active.Tower.SubIndex);
+            var overlay = world.SpawnEventObject(new EventObjectSpawnConfig
+            {
+                EObjId = TowerEObjId(active.Tower.Element),
+                Placement = new Placement(active.Tower.Position, 0f),
+                TimelineState = CelestriadTowerEObjId.ActiveState,
+            });
+            if (overlay is not null) activeOverlays[key] = overlay;
+        }
+    }
+
+    private void DeactivateTowers(int set)
+    {
+        foreach (var active in state.SetActiveTowers[set])
+        {
+            var key = (active.Tower.Element, active.Tower.SubIndex);
+            if (activeOverlays.Remove(key, out var overlay))
+                overlay.Despawn();
+        }
+    }
+
+    // Fireball / ice pillar / lightning strike burst on resolve, targeted dead-centre via the
+    // tower's own persistent invisible marker (spawned once in SpawnAllTowers). EventObjects
+    // (the towers themselves) don't resolve as valid single-target cast targets here, but a
+    // real (BattleChara-based) actor does, the same way a player does. The marker casts on
+    // itself rather than having Kefka cast at it: SimCast is one instance per caster, so a
+    // cast from Kefka here would fight over the same cast state as his Catastrophic Choice
+    // cast on Catastrophic Choice sets.
+    private void PlayResolveEffect(CelestriadTower tower)
+    {
+        if (!towerMarkers.TryGetValue((tower.Element, tower.SubIndex), out var marker)) return;
+        marker.Cast(ElementAction(tower.Element), castSeconds: 0f, targetId: marker.GameObjectId);
+    }
+
+    private void ResolveSet(int set)
+    {
+        var anyUnsoaked = false;
+        foreach (var active in state.SetActiveTowers[set])
+        {
+            var tower = active.Tower;
+            var inside = party.Find.InsideCircle(tower.Position, CelestriadGeometry.SoakRadius);
+            if (inside.Count < 2)
+            {
+                anyUnsoaked = true;
+                // Hard failure: whoever was assigned here dies, whether they showed up or not,
+                // on top of the party-wide penalty below.
+                foreach (var role in state.AssignedRoles(active, set))
+                    party.Get(role)?.Die("Celestriad, tower unsoaked");
+            }
+
+            PlayResolveEffect(tower);
+
+            // Soaking a tower gives its element's resistance-down, independent of whoever was
+            // originally debuffed with it.
+            foreach (var soaker in inside)
+                soaker.AddStatus(ElementDebuff(tower.Element), CelestriadTiming.DebuffDuration);
+
+            // Wrong-half Catastrophic Choice is a personal hit (death), not a party-wide
+            // penalty; that's reserved for an unsoaked tower, checked above.
+            if (state.AeroVariant[set] is { } aero)
+                foreach (var p in inside)
+                    if (!IsSafeHalf(p.Position, tower.Position, aero))
+                        p.Die("Catastrophic Choice");
+        }
+
+        if (!anyUnsoaked) return;
+        for (var i = 0; i < 8; i++)
+        {
+            var member = party.Get(i);
+            if (member is null || !member.IsAlive()) continue;
+            member.AddStatus(StatusId.DamageDown, CelestriadTiming.DamageDownDuration);
+        }
+    }
+
+    private void DespawnAllTowers()
+    {
+        foreach (var eobj in towerObjects.Values) eobj.Despawn();
+        towerObjects.Clear();
+        foreach (var eobj in activeOverlays.Values) eobj.Despawn();
+        activeOverlays.Clear();
+        foreach (var marker in towerMarkers.Values) marker.Despawn();
+        towerMarkers.Clear();
+    }
+
+    // Aero (green): safe half is away from the boss/centre. Earth (brown): safe half is toward
+    // the boss/centre.
+    private static bool IsSafeHalf(Vector3 playerPos, Vector3 towerPos, bool aero)
+    {
+        var inward = -Vector3.Normalize(towerPos);
+        var dot = Vector3.Dot(playerPos - towerPos, inward);
+        return aero ? dot < 0f : dot > 0f;
+    }
+
+    private static uint TowerEObjId(CelestriadElement e) => e switch
+    {
+        CelestriadElement.Fire => CelestriadTowerEObjId.Fire,
+        CelestriadElement.Ice => CelestriadTowerEObjId.Ice,
+        _ => CelestriadTowerEObjId.Lightning,
+    };
+
+    private static uint ElementAction(CelestriadElement e) => e switch
+    {
+        CelestriadElement.Fire => CelestriadActionId.FireIII,
+        CelestriadElement.Ice => CelestriadActionId.BlizzardIII,
+        _ => CelestriadActionId.ThunderIII,
+    };
+
+    private static ushort ElementDebuff(CelestriadElement e) => e switch
+    {
+        CelestriadElement.Fire => CelestriadStatusId.FireResistanceDownII,
+        CelestriadElement.Ice => CelestriadStatusId.IceResistanceDownII,
+        _ => StatusId.LightningResistanceDownII, // shared UmadConstants.StatusId, same value as ForsakenNull's local copy
+    };
+}

--- a/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadScenario.cs
+++ b/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadScenario.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using AnoMech.Core.Game;
 using AnoMech.Core.Game.Ai;
+using AnoMech.Core.Game.Party;
 using AnoMech.Core.SimObjects;
 using static AnoMech.Scenarios.Umad.UmadConstants;
 using static AnoMech.Scenarios.Umad.P5Celestriad.UmadP5CelestriadConstants;
@@ -34,6 +36,7 @@ public sealed class UmadP5CelestriadScenario : IScenario
     private UmadP5CelestriadState state = null!;
     private SimWorld world = null!;
     private SimParty party = null!;
+    private DamageSolver damage = null!;
     private SimEnemy? kefka;
     private readonly Dictionary<(CelestriadElement, int), SimEventObject> towerObjects = new();
     private readonly Dictionary<(CelestriadElement, int), SimEventObject> activeOverlays = new();
@@ -44,6 +47,7 @@ public sealed class UmadP5CelestriadScenario : IScenario
         world = worldParam;
         party = worldParam.Party;
         state = new UmadP5CelestriadState(party, settingsWindow.Overrides);
+        damage = new DamageSolver(party);
         towerObjects.Clear();
         activeOverlays.Clear();
         towerMarkers.Clear();
@@ -63,6 +67,7 @@ public sealed class UmadP5CelestriadScenario : IScenario
             world.Events.Add(CelestriadTiming.TowerStart[s], () => ActivateTowers(s));
             if (CelestriadTiming.CcAt[s] is { } cc) world.Events.Add(cc, () => LaunchChoice(s));
             world.Events.Add(CelestriadTiming.ResolveAt[s], () => ResolveSet(s));
+            world.Events.Add(CelestriadTiming.ResolveAt[s], () => SpawnChoiceOmen(s));
             world.Events.Add(CelestriadTiming.DeactivateAt[s], () => DeactivateTowers(s));
         }
 
@@ -95,17 +100,26 @@ public sealed class UmadP5CelestriadScenario : IScenario
         }
     }
 
-    // One cast per applicable set; that set resolves exactly when this cast completes. The
-    // green donut / black circle is duty-scripted decoration in retail, not part of the
-    // action's own release animation, so it needs its own telegraph spawn (matching
-    // TopUtils.ResolveOpticalLaser's pattern for the same kind of scripted-visual gap) rather
-    // than relying on the cast to produce it.
+    // One cast per applicable set; that set resolves exactly when this cast completes.
     private void LaunchChoice(int set)
     {
         if (state.AeroVariant[set] is not { } aero || kefka is null) return;
         var actionId = aero ? CelestriadActionId.CatastrophicChoiceAero : CelestriadActionId.CatastrophicChoiceEarth;
         kefka.Cast(actionId, castSeconds: CelestriadTiming.CatastrophicChoiceCastTime);
-        world.SpawnActionOmen(actionId, Vector3.Zero, kefka.Rotation, CelestriadTiming.CatastrophicChoiceCastTime);
+    }
+
+    // The green donut / black circle is duty-scripted decoration in retail, not part of the
+    // action's own release animation, so it needs its own spawn (matching
+    // TopUtils.ResolveOpticalLaser's pattern for the same kind of scripted-visual gap) rather
+    // than relying on the cast to produce it. Fired at resolution, not cast start, matching
+    // ResolveOpticalLaser's own timing: this flashes the result over the affected zone rather
+    // than acting as an advance telegraph (players read Aero/Earth from the cast itself, not
+    // from this), same as the tower resolve VFX right below it.
+    private void SpawnChoiceOmen(int set)
+    {
+        if (state.AeroVariant[set] is not { } aero || kefka is null) return;
+        var actionId = aero ? CelestriadActionId.CatastrophicChoiceAero : CelestriadActionId.CatastrophicChoiceEarth;
+        world.SpawnActionOmen(actionId, Vector3.Zero, kefka.Rotation, durationSeconds: 1.5f);
     }
 
     // Real tower props (EObjId per UmadP5CelestriadConstants), not a cast/omen. All 9 spawn once
@@ -147,13 +161,13 @@ public sealed class UmadP5CelestriadScenario : IScenario
 
     private void ActivateTowers(int set)
     {
-        foreach (var active in state.SetActiveTowers[set])
+        foreach (var tower in state.SetActiveTowers[set])
         {
-            var key = (active.Tower.Element, active.Tower.SubIndex);
+            var key = (tower.Element, tower.SubIndex);
             var overlay = world.SpawnEventObject(new EventObjectSpawnConfig
             {
-                EObjId = TowerEObjId(active.Tower.Element),
-                Placement = new Placement(active.Tower.Position, 0f),
+                EObjId = TowerEObjId(tower.Element),
+                Placement = new Placement(tower.Position, 0f),
                 TimelineState = CelestriadTowerEObjId.ActiveState,
             });
             if (overlay is not null) activeOverlays[key] = overlay;
@@ -162,9 +176,9 @@ public sealed class UmadP5CelestriadScenario : IScenario
 
     private void DeactivateTowers(int set)
     {
-        foreach (var active in state.SetActiveTowers[set])
+        foreach (var tower in state.SetActiveTowers[set])
         {
-            var key = (active.Tower.Element, active.Tower.SubIndex);
+            var key = (tower.Element, tower.SubIndex);
             if (activeOverlays.Remove(key, out var overlay))
                 overlay.Despawn();
         }
@@ -183,35 +197,51 @@ public sealed class UmadP5CelestriadScenario : IScenario
         marker.Cast(ElementAction(tower.Element), castSeconds: 0f, targetId: marker.GameObjectId);
     }
 
+    // The scenario's own ruleset resolution: independent of how the AI chose to distribute
+    // players across a doubled element's 2 towers, only the aggregate per-element outcome
+    // matters here. RequiredRoles below is a scenario-ruleset fact derived straight from
+    // state's raw randomness (who's debuffed, who's free, which element doubles), not a
+    // strategy decision, so the scenario can resolve independently of the AI's own logic.
     private void ResolveSet(int set)
     {
         var anyUnsoaked = false;
-        foreach (var active in state.SetActiveTowers[set])
+        foreach (var group in state.SetActiveTowers[set].GroupBy(t => t.Element))
         {
-            var tower = active.Tower;
-            var inside = party.Find.InsideCircle(tower.Position, CelestriadGeometry.SoakRadius);
-            if (inside.Count < 2)
+            var required = RequiredRoles(group.Key, set).ToHashSet();
+            var present = new HashSet<PartyRole>();
+
+            foreach (var tower in group)
             {
-                anyUnsoaked = true;
-                // Hard failure: whoever was assigned here dies, whether they showed up or not,
-                // on top of the party-wide penalty below.
-                foreach (var role in state.AssignedRoles(active, set))
-                    party.Get(role)?.Die("Celestriad, tower unsoaked");
+                // DamageSolver kills whoever's physically present if the tower comes up short
+                // (stackMinTargets), and applies the element's resistance-down to survivors.
+                var soakers = damage.Resolve(towerMarkers.GetValueOrDefault((tower.Element, tower.SubIndex)),
+                    ElementAction(tower.Element), [], [(ElementDebuff(tower.Element), CelestriadTiming.DebuffDuration)],
+                    stackMinTargets: 2, size: CelestriadGeometry.SoakRadius);
+                if (soakers.Count < 2) anyUnsoaked = true;
+                foreach (var soaker in soakers)
+                    if (soaker is ISimPartyMember pm) present.Add(pm.Role);
+
+                PlayResolveEffect(tower);
             }
 
-            PlayResolveEffect(tower);
+            // Hard failure: anyone required for this element who wasn't found at any of its
+            // active towers this set dies, whether they showed up short-handed or not at all,
+            // on top of the party-wide penalty below.
+            foreach (var role in required.Except(present))
+            {
+                anyUnsoaked = true;
+                party.Get(role)?.Die("Celestriad, tower unsoaked");
+            }
+        }
 
-            // Soaking a tower gives its element's resistance-down, independent of whoever was
-            // originally debuffed with it.
-            foreach (var soaker in inside)
-                soaker.AddStatus(ElementDebuff(tower.Element), CelestriadTiming.DebuffDuration);
-
-            // Wrong-half Catastrophic Choice is a personal hit (death), not a party-wide
-            // penalty; that's reserved for an unsoaked tower, checked above.
-            if (state.AeroVariant[set] is { } aero)
-                foreach (var p in inside)
-                    if (!IsSafeHalf(p.Position, tower.Position, aero))
-                        p.Die("Catastrophic Choice");
+        // Wrong-half Catastrophic Choice is a personal hit (death), not a party-wide penalty;
+        // that's reserved for an unsoaked tower, checked above. Arena-wide (not per-tower):
+        // DamageSolver reads the real safe/danger split straight off the action's own sheet
+        // data (CastType/EffectRange), rather than an approximated distance-from-centre check.
+        if (state.AeroVariant[set] is { } aero && kefka is not null)
+        {
+            var actionId = aero ? CelestriadActionId.CatastrophicChoiceAero : CelestriadActionId.CatastrophicChoiceEarth;
+            damage.Resolve(kefka, actionId, [DamageType.Lethal], []);
         }
 
         if (!anyUnsoaked) return;
@@ -221,6 +251,19 @@ public sealed class UmadP5CelestriadScenario : IScenario
             if (member is null || !member.IsAlive()) continue;
             member.AddStatus(StatusId.DamageDown, CelestriadTiming.DamageDownDuration);
         }
+    }
+
+    // Every player required to be somewhere among element's active towers this set: the 2
+    // players whose cycling debuff currently points at element, plus (only when element is
+    // this set's doubled element) the 2 free players filling its second tower.
+    private IEnumerable<PartyRole> RequiredRoles(CelestriadElement element, int set)
+    {
+        var debuffed = state.PlayerDebuffElement
+            .Where(kv => kv.Value is not null && state.ElementForSet(kv.Key, set) == element)
+            .Select(kv => kv.Key);
+        if (element != state.DoubleElement[set]) return debuffed;
+        var free = state.PlayerDebuffElement.Where(kv => kv.Value is null).Select(kv => kv.Key);
+        return debuffed.Concat(free);
     }
 
     private void DespawnAllTowers()
@@ -233,14 +276,6 @@ public sealed class UmadP5CelestriadScenario : IScenario
         towerMarkers.Clear();
     }
 
-    // Aero (green): safe half is away from the boss/centre. Earth (brown): safe half is toward
-    // the boss/centre.
-    private static bool IsSafeHalf(Vector3 playerPos, Vector3 towerPos, bool aero)
-    {
-        var inward = -Vector3.Normalize(towerPos);
-        var dot = Vector3.Dot(playerPos - towerPos, inward);
-        return aero ? dot < 0f : dot > 0f;
-    }
 
     private static uint TowerEObjId(CelestriadElement e) => e switch
     {

--- a/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadSettingsWindow.cs
+++ b/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadSettingsWindow.cs
@@ -1,0 +1,45 @@
+using System;
+using Dalamud.Bindings.ImGui;
+
+namespace AnoMech.Scenarios.Umad.P5Celestriad;
+
+// Settings panel for the P5 Celestriad scenario: force the player's own element/free
+// assignment and each Catastrophic Choice set's variant, or leave them randomized.
+// Mirrors UmadP5ExaflaresSettingsWindow (SettingsGrid two-column layout, "Auto" reset).
+public sealed class UmadP5CelestriadSettingsWindow
+{
+    public UmadP5CelestriadStateOverrides Overrides { get; } = new();
+
+    private static readonly string[] ElementLabels = ["Random", "Fire", "Ice", "Lightning", "Free"];
+    private static readonly string[] VariantLabels = ["Random", "Aero (green)", "Earth (brown)"];
+
+    public void Draw()
+    {
+        if (ImGui.Button("Auto"))
+        {
+            Overrides.PlayerElement = CelestriadElementOverride.Random;
+            Overrides.Set1 = CatastrophicVariantOverride.Random;
+            Overrides.Set3 = CatastrophicVariantOverride.Random;
+        }
+
+        if (SettingsGrid.Begin("##p5celestriad"))
+        {
+            DrawRow("Your element:", "##playerelement", ElementLabels, (int)Overrides.PlayerElement,
+                v => Overrides.PlayerElement = (CelestriadElementOverride)v);
+            DrawRow("Set 1 variant:", "##set1variant", VariantLabels, (int)Overrides.Set1,
+                v => Overrides.Set1 = (CatastrophicVariantOverride)v);
+            DrawRow("Set 3 variant:", "##set3variant", VariantLabels, (int)Overrides.Set3,
+                v => Overrides.Set3 = (CatastrophicVariantOverride)v);
+            SettingsGrid.End();
+        }
+    }
+
+    private static void DrawRow(string label, string id, string[] labels, int current, Action<int> set)
+    {
+        SettingsGrid.Row(label);
+        var idx = current;
+        ImGui.SetNextItemWidth(140);
+        if (ImGui.Combo(id, ref idx, labels, labels.Length))
+            set(idx);
+    }
+}

--- a/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadState.cs
+++ b/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadState.cs
@@ -15,15 +15,17 @@ public enum CelestriadElement { Fire, Lightning, Ice }
 // One of the 9 fixed towers, spawned once for the whole mechanic; position never changes.
 public sealed record CelestriadTower(CelestriadElement Element, int SubIndex, Vector3 Position);
 
-// A tower that's active (lit) this set. IsFreeTower marks the doubled element's second active
-// tower, the one the two undebuffed players fill, rather than that element's own dedicated pair.
-public sealed record CelestriadActiveTower(CelestriadTower Tower, bool IsFreeTower);
-
 // Per-run randomization: which element (or "free") each party role is permanently debuffed
 // with, which element doubles up on each of the 3 sets, which of its 3 ring towers are active,
 // and (sets 0 and 2 only, the 1st and 3rd soaks) whether that set's single Catastrophic Choice
 // is Aero (green, safe toward centre) or Earth (brown, safe away from centre). ElementForSet
 // derives each role's actual per-set soak target from its debuff.
+//
+// Deliberately has no notion of which specific player goes to which specific active tower
+// within a doubled element's pair, or who's "responsible" for a tower failing: that's a
+// strategy decision (the AI's job, see UmadP5CelestriadAi) and a scenario-ruleset resolution
+// decision (the scenario's job, see UmadP5CelestriadScenario.ResolveSet), not a fact of the
+// randomization itself. State only ever exposes what's actually random.
 public sealed class UmadP5CelestriadState
 {
     private readonly Rng rng = new();
@@ -40,22 +42,13 @@ public sealed class UmadP5CelestriadState
     public IReadOnlyDictionary<PartyRole, CelestriadElement?> PlayerDebuffElement { get; }
     public IReadOnlyList<CelestriadElement> DoubleElement { get; }
     public IReadOnlyList<CelestriadTower> AllTowers { get; }
-    public IReadOnlyList<IReadOnlyList<CelestriadActiveTower>> SetActiveTowers { get; }
+    public IReadOnlyList<IReadOnlyList<CelestriadTower>> SetActiveTowers { get; }
     public IReadOnlyList<bool?> AeroVariant { get; }
 
     // The element this role should physically soak at this set. NOT the same as their permanent
     // debuff except in set 2. Free (undebuffed) players always fill in for the doubled element.
     public CelestriadElement ElementForSet(PartyRole role, int set) =>
         PlayerDebuffElement[role] is { } own ? (CelestriadElement)(((int)own + SetOffset[set]) % 3) : DoubleElement[set];
-
-    // The two roles that belong at this active tower this set. Shared by the AI (where to send
-    // bots) and the resolve check (who to penalize if the tower ends up unsoaked).
-    public IEnumerable<PartyRole> AssignedRoles(CelestriadActiveTower active, int set) =>
-        PlayerDebuffElement
-            .Where(kv => active.IsFreeTower
-                ? kv.Value is null
-                : kv.Value is not null && ElementForSet(kv.Key, set) == active.Tower.Element)
-            .Select(kv => kv.Key);
 
     public UmadP5CelestriadState(SimParty party, UmadP5CelestriadStateOverrides overrides)
     {
@@ -92,22 +85,20 @@ public sealed class UmadP5CelestriadState
                 allTowers.Add(new CelestriadTower(element, sub, TowerPosition(element, sub)));
         AllTowers = allTowers;
 
-        var setActive = new List<IReadOnlyList<CelestriadActiveTower>>(3);
+        var setActive = new List<IReadOnlyList<CelestriadTower>>(3);
         var aero = new List<bool?>(3);
         for (var set = 0; set < 3; set++)
         {
-            var active = new List<CelestriadActiveTower>(4);
+            var active = new List<CelestriadTower>(4);
             foreach (var element in Elements)
             {
                 var elementTowers = allTowers.Where(t => t.Element == element).ToArray();
                 var isDouble = element == DoubleElement[set];
-                // Which sub-towers light up is random; which is "first"/"second" clockwise in
-                // the pair is not. Sort ascending so the debuffed pair always gets the
-                // clockwise-first active tower and the free pair always gets the clockwise-second.
+                // Which sub-towers light up is random; sorted ascending so a doubled element's
+                // pair always lists in a stable, deterministic clockwise order for whoever reads
+                // "first" vs "second" out of it (the AI, when deciding who goes where).
                 var subs = rng.Shuffle(0, 1, 2).Take(isDouble ? 2 : 1).OrderBy(s => s).ToArray();
-                active.Add(new CelestriadActiveTower(elementTowers[subs[0]], false));
-                if (isDouble)
-                    active.Add(new CelestriadActiveTower(elementTowers[subs[1]], true));
+                active.AddRange(subs.Select(s => elementTowers[s]));
             }
             setActive.Add(active);
             aero.Add(ResolveAero(set, overrides));

--- a/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadState.cs
+++ b/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadState.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using AnoMech.Core.Game.Party;
+using AnoMech.Core.SimObjects;
+using static AnoMech.Scenarios.Umad.P5Celestriad.UmadP5CelestriadConstants;
+
+namespace AnoMech.Scenarios.Umad.P5Celestriad;
+
+// Declared in the confirmed real clockwise ring order (Fire block, then Lightning block, then
+// Ice block): ElementForSet's cyclic shift relies on this order to mean "next clockwise".
+public enum CelestriadElement { Fire, Lightning, Ice }
+
+// One of the 9 fixed towers, spawned once for the whole mechanic; position never changes.
+public sealed record CelestriadTower(CelestriadElement Element, int SubIndex, Vector3 Position);
+
+// A tower that's active (lit) this set. IsFreeTower marks the doubled element's second active
+// tower, the one the two undebuffed players fill, rather than that element's own dedicated pair.
+public sealed record CelestriadActiveTower(CelestriadTower Tower, bool IsFreeTower);
+
+// Per-run randomization: which element (or "free") each party role is permanently debuffed
+// with, which element doubles up on each of the 3 sets, which of its 3 ring towers are active,
+// and (sets 0 and 2 only, the 1st and 3rd soaks) whether that set's single Catastrophic Choice
+// is Aero (green, safe toward centre) or Earth (brown, safe away from centre). ElementForSet
+// derives each role's actual per-set soak target from its debuff.
+public sealed class UmadP5CelestriadState
+{
+    private readonly Rng rng = new();
+
+    // Cyclic shift applied to a debuffed player's own element index to get their set-s soak
+    // target: set 0 -> next element, set 1 -> element after that, set 2 -> own element again.
+    // Since this is a fixed shift of a 3-element cycle, it's automatically a bijection each set
+    // (exactly one debuff group per element) and never repeats an element across the 3 sets.
+    private static readonly int[] SetOffset = { 1, 2, 0 };
+
+    private static readonly CelestriadElement[] Elements =
+        { CelestriadElement.Fire, CelestriadElement.Lightning, CelestriadElement.Ice };
+
+    public IReadOnlyDictionary<PartyRole, CelestriadElement?> PlayerDebuffElement { get; }
+    public IReadOnlyList<CelestriadElement> DoubleElement { get; }
+    public IReadOnlyList<CelestriadTower> AllTowers { get; }
+    public IReadOnlyList<IReadOnlyList<CelestriadActiveTower>> SetActiveTowers { get; }
+    public IReadOnlyList<bool?> AeroVariant { get; }
+
+    // The element this role should physically soak at this set. NOT the same as their permanent
+    // debuff except in set 2. Free (undebuffed) players always fill in for the doubled element.
+    public CelestriadElement ElementForSet(PartyRole role, int set) =>
+        PlayerDebuffElement[role] is { } own ? (CelestriadElement)(((int)own + SetOffset[set]) % 3) : DoubleElement[set];
+
+    // The two roles that belong at this active tower this set. Shared by the AI (where to send
+    // bots) and the resolve check (who to penalize if the tower ends up unsoaked).
+    public IEnumerable<PartyRole> AssignedRoles(CelestriadActiveTower active, int set) =>
+        PlayerDebuffElement
+            .Where(kv => active.IsFreeTower
+                ? kv.Value is null
+                : kv.Value is not null && ElementForSet(kv.Key, set) == active.Tower.Element)
+            .Select(kv => kv.Key);
+
+    public UmadP5CelestriadState(SimParty party, UmadP5CelestriadStateOverrides overrides)
+    {
+        // Each element doubles exactly once across the 3 sets: a shuffled permutation
+        // guarantees that instead of leaving it to independent per-set coin flips.
+        DoubleElement = rng.Shuffle(CelestriadElement.Fire, CelestriadElement.Ice, CelestriadElement.Lightning);
+
+        var roles = RoleList.Random(party).List;
+        var buckets = new CelestriadElement?[]
+        {
+            CelestriadElement.Fire, CelestriadElement.Fire,
+            CelestriadElement.Ice, CelestriadElement.Ice,
+            CelestriadElement.Lightning, CelestriadElement.Lightning,
+            null, null,
+        };
+        if (overrides.PlayerElement != CelestriadElementOverride.Random)
+        {
+            CelestriadElement? wanted = overrides.PlayerElement switch
+            {
+                CelestriadElementOverride.Fire => CelestriadElement.Fire,
+                CelestriadElementOverride.Ice => CelestriadElement.Ice,
+                CelestriadElementOverride.Lightning => CelestriadElement.Lightning,
+                _ => null, // Free
+            };
+            var playerIdx = Array.IndexOf(roles, party.PlayerRole);
+            var wantedIdx = Array.FindIndex(buckets, b => b == wanted);
+            (roles[playerIdx], roles[wantedIdx]) = (roles[wantedIdx], roles[playerIdx]);
+        }
+        PlayerDebuffElement = Enumerable.Range(0, 8).ToDictionary(i => roles[i], i => buckets[i]);
+
+        var allTowers = new List<CelestriadTower>(9);
+        foreach (var element in Elements)
+            for (var sub = 0; sub < 3; sub++)
+                allTowers.Add(new CelestriadTower(element, sub, TowerPosition(element, sub)));
+        AllTowers = allTowers;
+
+        var setActive = new List<IReadOnlyList<CelestriadActiveTower>>(3);
+        var aero = new List<bool?>(3);
+        for (var set = 0; set < 3; set++)
+        {
+            var active = new List<CelestriadActiveTower>(4);
+            foreach (var element in Elements)
+            {
+                var elementTowers = allTowers.Where(t => t.Element == element).ToArray();
+                var isDouble = element == DoubleElement[set];
+                // Which sub-towers light up is random; which is "first"/"second" clockwise in
+                // the pair is not. Sort ascending so the debuffed pair always gets the
+                // clockwise-first active tower and the free pair always gets the clockwise-second.
+                var subs = rng.Shuffle(0, 1, 2).Take(isDouble ? 2 : 1).OrderBy(s => s).ToArray();
+                active.Add(new CelestriadActiveTower(elementTowers[subs[0]], false));
+                if (isDouble)
+                    active.Add(new CelestriadActiveTower(elementTowers[subs[1]], true));
+            }
+            setActive.Add(active);
+            aero.Add(ResolveAero(set, overrides));
+        }
+        SetActiveTowers = setActive;
+        AeroVariant = aero;
+    }
+
+    private bool? ResolveAero(int set, UmadP5CelestriadStateOverrides overrides) => set switch
+    {
+        0 => overrides.Set1 switch
+        {
+            CatastrophicVariantOverride.Aero => true,
+            CatastrophicVariantOverride.Earth => false,
+            _ => rng.NextBool(),
+        },
+        2 => overrides.Set3 switch
+        {
+            CatastrophicVariantOverride.Aero => true,
+            CatastrophicVariantOverride.Earth => false,
+            _ => rng.NextBool(),
+        },
+        _ => null, // set 1 (index 1, the "second" soak) has no Catastrophic Choice
+    };
+
+    // 9 towers 40 degrees apart clockwise from north, grouped as 3 contiguous per-element blocks
+    // (not interleaved) starting 20 degrees off north, confirmed against the real EObj spawn
+    // positions (see UmadP5CelestriadConstants). subIndex selects which of an element's 3 ring spots.
+    public static Vector3 TowerPosition(CelestriadElement element, int subIndex)
+    {
+        var ringIndex = (int)element * 3 + subIndex;
+        var angle = MathF.PI / 9f + ringIndex * (MathF.PI * 2f / 9f);
+        return new Vector3(MathF.Sin(angle) * CelestriadGeometry.RingRadius, 0f, -MathF.Cos(angle) * CelestriadGeometry.RingRadius);
+    }
+}

--- a/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadStateOverrides.cs
+++ b/AnoMech/Scenarios/Umad/P5Celestriad/UmadP5CelestriadStateOverrides.cs
@@ -1,0 +1,15 @@
+namespace AnoMech.Scenarios.Umad.P5Celestriad;
+
+public enum CelestriadElementOverride { Random, Fire, Ice, Lightning, Free }
+
+public enum CatastrophicVariantOverride { Random, Aero, Earth }
+
+// User-controlled overrides for UmadP5CelestriadState's randomized fields. Bound by the
+// scenario's settings UI; Random leaves the field randomized at scenario start. Same shape
+// as UmadP5ExaflaresStateOverrides.
+public sealed class UmadP5CelestriadStateOverrides
+{
+    public CelestriadElementOverride PlayerElement { get; set; } = CelestriadElementOverride.Random;
+    public CatastrophicVariantOverride Set1 { get; set; } = CatastrophicVariantOverride.Random;
+    public CatastrophicVariantOverride Set3 { get; set; } = CatastrophicVariantOverride.Random;
+}


### PR DESCRIPTION
## Summary
- Implements the tower-soak mechanic from Dancing Mad Ultimate P5 (Celestriad): 9 towers (3 each of Fire/Ice/Lightning) spawn once and persist for the whole mechanic, with each of 3 sets lighting up 4 for a soak.
- Debuffed players cycle through elements across the 3 sets (never soaking their own debuff element until the final set); free (undebuffed) players fill the doubled element's second tower each set.
- Sets 0 and 2 add a Catastrophic Choice (Aero/Earth) half-soak on top of the regular tower soak.
- Missing a tower soak kills the assigned players and applies a party-wide DamageDown; standing on the wrong Catastrophic Choice half is a personal death only.
- Adds two small supporting engine additions: `SimWorld.SpawnActionOmen` (a standalone telegraph derived from an action's own Omen sheet entry, for abilities whose real telegraph is duty-scripted rather than driven by the caster's own cast) and a `GameObjectId` accessor on `SimEventObject` mirroring `SimCharacter`'s.

Timings and IDs are sourced from a replay-confirmed Celestriad attempt (see header comment in `UmadP5CelestriadConstants.cs` for what's confirmed vs. estimated).

## Test plan
- [x] `dotnet build` succeeds clean
- [x] Manually run in-game via `/anomech` in an inn: towers spawn/activate/deactivate/despawn correctly, debuffs apply silently, soak resolution and Catastrophic Choice both fire their VFX, unsoaked towers and wrong-half Catastrophic Choice apply the correct death/DamageDown semantics