### PR TITLE
Add a consecutive-success mechanic streak, with optional auto-restart

### DIFF
--- a/AnoMech/Core/Game/EventScheduler.cs
+++ b/AnoMech/Core/Game/EventScheduler.cs
@@ -13,6 +13,12 @@ public sealed class EventScheduler
     private readonly List<Entry> entries = new();
     private float elapsed;
 
+    // No more scheduled work. A scenario's whole timeline lives in this queue, so this
+    // doubles as a generic "reached its declared end" signal for whoever's watching (Game
+    // uses it to infer a clean run for the mechanic-streak counter) without needing scenarios
+    // to report completion themselves.
+    public bool IsEmpty => entries.Count == 0;
+
     public void Add(float offset, Action action)
     {
         var time = elapsed + MathF.Max(0f, offset);

--- a/AnoMech/Core/Game/Game.cs
+++ b/AnoMech/Core/Game/Game.cs
@@ -60,6 +60,39 @@ public sealed class Game : IDisposable
     // gameplay side effect (HP=0, KO timeline, stun hooks, freeze timer).
     public bool GodMode { get; set; }
 
+    // When true, a successful run (see UpdateMechanicResult) immediately starts the same
+    // scenario again with the same parameters, for hands-free repetition. A real death
+    // cancels it (set false directly in Kill) rather than restarting past a failure the
+    // freeze/overlay exists to let the user actually see.
+    public bool AutoRestart { get; set; }
+    private IScenario? lastRunScenario;
+    private PartyRole? lastRunRoleOverride;
+    private int? lastRunSelectedAi;
+    private int lastRunSelectedWaymark;
+
+    // Consecutive successful completions of whatever scenario is currently active. Reset by
+    // Kill on any real (non-godmode) death and by RunScenarioInternal when a different
+    // scenario starts. Incremented automatically once IScenario.IsFinished reports true and
+    // stays true for MechanicResultSettleSeconds (see UpdateMechanicResult): no per-scenario
+    // reporting needed. In-memory only: does not survive a plugin reload.
+    public int MechanicStreak { get; private set; }
+
+    // How long IsFinished has to stay true before it counts as "reached the end cleanly".
+    // Covers a death whose failure check trails a few frames behind the scenario's own
+    // last scheduled action (rather than firing in the exact same frame, which the Tick
+    // call order below already handles on its own).
+    private const float MechanicResultSettleSeconds = 1f;
+    private float? scenarioFinishedElapsed;
+    private bool mechanicResultReported;
+
+    // Set by Kill on any real death, scoped to the current run (cleared by ResetInternal).
+    // IsFinished can go true on a queue that Kill's own freeze-timer event never touches
+    // (e.g. a scenario with a private EventScheduler immune to EventTimeScale): there's no
+    // structural guarantee that queue and the freeze timer interleave correctly the way two
+    // entries on the same Events queue would, so this flag is the actual source of truth for
+    // "did this run fail", independent of any queue or timing race.
+    private bool deathOccurredThisRun;
+
     private IScenario? activeScenario;
     private float scenarioElapsed;
     private bool firstDeathScheduled;
@@ -117,6 +150,10 @@ public sealed class Game : IDisposable
     // selectedWaymark: index into the scenario's WaymarkPresets; ignored when it has none.
     public void RunScenario(IScenario scenario, PartyRole? roleOverride = null, int? selectedAi = 0, int selectedWaymark = 0)
     {
+        lastRunScenario = scenario;
+        lastRunRoleOverride = roleOverride;
+        lastRunSelectedAi = selectedAi;
+        lastRunSelectedWaymark = selectedWaymark;
         Plugin.Framework.Run(() => RunScenarioInternal(scenario, roleOverride, selectedAi, selectedWaymark));
     }
 
@@ -143,6 +180,9 @@ public sealed class Game : IDisposable
             return;
         }
 
+        // Captured before ResetInternal clears activeScenario, so restarting the same
+        // scenario (the normal way to extend a streak) doesn't look like a switch.
+        var previousScenario = activeScenario;
         ResetInternal();
 
         var player = Plugin.ObjectTable.LocalPlayer;
@@ -175,6 +215,8 @@ public sealed class Game : IDisposable
         else
             TeleportPlayerToSpawnIfOutsideArena();
         ResetSprintCooldown();
+        if (previousScenario != scenario)
+            MechanicStreak = 0;
         activeScenario = scenario;
         scenarioElapsed = 0f;
 
@@ -218,7 +260,31 @@ public sealed class Game : IDisposable
         {
             scenarioElapsed += deltaSeconds;
             activeScenario.Tick(deltaSeconds, scenarioElapsed);
+            UpdateMechanicResult(deltaSeconds);
         }
+    }
+
+    // Infers a clean run from IScenario.IsFinished going true and staying true, rather than
+    // needing each scenario to report its own completion. deathOccurredThisRun (set by Kill,
+    // independent of whichever queue IsFinished watches) is the actual gate against a failed
+    // run being mistaken for a clean one: a queue running dry is not by itself proof nothing
+    // died, since Kill's own freeze-timer event lives on Events specifically and a scenario's
+    // IsFinished override may watch a different queue entirely.
+    private void UpdateMechanicResult(float deltaSeconds)
+    {
+        if (mechanicResultReported) return;
+        if (activeScenario is null || !activeScenario.IsFinished(World))
+        {
+            scenarioFinishedElapsed = null;
+            return;
+        }
+        scenarioFinishedElapsed = (scenarioFinishedElapsed ?? 0f) + deltaSeconds;
+        if (scenarioFinishedElapsed < MechanicResultSettleSeconds) return;
+        mechanicResultReported = true;
+        if (deathOccurredThisRun) return;
+        MechanicStreak++;
+        if (AutoRestart && lastRunScenario is { } scenario)
+            RunScenario(scenario, lastRunRoleOverride, lastRunSelectedAi, lastRunSelectedWaymark);
     }
 
     // Godmode preview: how long a swallowed-death HP-bar drop stays down before healing back.
@@ -265,6 +331,9 @@ public sealed class Game : IDisposable
             return false;
         }
         target.OnKilled();
+        MechanicStreak = 0;
+        deathOccurredThisRun = true;
+        AutoRestart = false;
         if (!firstFreezeScheduled)
         {
             firstFreezeScheduled = true;
@@ -359,6 +428,9 @@ public sealed class Game : IDisposable
         Paused = false;
         firstDeathScheduled = false;
         firstFreezeScheduled = false;
+        scenarioFinishedElapsed = null;
+        mechanicResultReported = false;
+        deathOccurredThisRun = false;
 #if DEBUG
         AnoMech.Windows.DamageDebugWindow.Instance?.ResetFreeze();
 #endif

--- a/AnoMech/Core/Game/Game.cs
+++ b/AnoMech/Core/Game/Game.cs
@@ -65,10 +65,7 @@ public sealed class Game : IDisposable
     // cancels it (set false directly in Kill) rather than restarting past a failure the
     // freeze/overlay exists to let the user actually see.
     public bool AutoRestart { get; set; }
-    private IScenario? lastRunScenario;
-    private PartyRole? lastRunRoleOverride;
-    private int? lastRunSelectedAi;
-    private int lastRunSelectedWaymark;
+    private RunScenarioParams? lastRun;
 
     // Consecutive successful completions of whatever scenario is currently active. Reset by
     // Kill on any real (non-godmode) death and by RunScenarioInternal when a different
@@ -149,12 +146,12 @@ public sealed class Game : IDisposable
     // solo (no doppels, no AI). Defaults to 0 = run the first strat with a full party.
     // selectedWaymark: index into the scenario's WaymarkPresets; ignored when it has none.
     public void RunScenario(IScenario scenario, PartyRole? roleOverride = null, int? selectedAi = 0, int selectedWaymark = 0)
+        => RunScenario(new RunScenarioParams(scenario, roleOverride, selectedAi, selectedWaymark));
+
+    private void RunScenario(RunScenarioParams p)
     {
-        lastRunScenario = scenario;
-        lastRunRoleOverride = roleOverride;
-        lastRunSelectedAi = selectedAi;
-        lastRunSelectedWaymark = selectedWaymark;
-        Plugin.Framework.Run(() => RunScenarioInternal(scenario, roleOverride, selectedAi, selectedWaymark));
+        lastRun = p;
+        Plugin.Framework.Run(() => RunScenarioInternal(p.Scenario, p.RoleOverride, p.SelectedAi, p.SelectedWaymark));
     }
 
     // The selected preset, or [0] as the default.
@@ -283,8 +280,8 @@ public sealed class Game : IDisposable
         mechanicResultReported = true;
         if (deathOccurredThisRun) return;
         MechanicStreak++;
-        if (AutoRestart && lastRunScenario is { } scenario)
-            RunScenario(scenario, lastRunRoleOverride, lastRunSelectedAi, lastRunSelectedWaymark);
+        if (AutoRestart && lastRun is { } p)
+            RunScenario(p);
     }
 
     // Godmode preview: how long a swallowed-death HP-bar drop stays down before healing back.
@@ -451,3 +448,7 @@ public sealed class Game : IDisposable
         opcodeUpdater.Dispose();
     }
 }
+
+// A single RunScenario call's arguments, bundled so Game can replay the exact same run (see
+// AutoRestart) without tracking each argument as its own field.
+public sealed record RunScenarioParams(IScenario Scenario, PartyRole? RoleOverride, int? SelectedAi, int SelectedWaymark);

--- a/AnoMech/Scenarios/IScenario.cs
+++ b/AnoMech/Scenarios/IScenario.cs
@@ -22,4 +22,12 @@ public interface IScenario
     void Run(SimWorld world, int? selectedAi);
     void Tick(float delta, float elapsed) { }
     void DrawSettings() { }
+
+    // Whether the scenario has reached its own natural end, for Game's mechanic-streak
+    // tracking. Default covers scenarios whose whole timeline lives on world.Events (the
+    // common case: nothing to override). A scenario that schedules its mechanic on a private
+    // EventScheduler instead (e.g. one kept immune to EventTimeScale for real-time precision)
+    // must override this to check that queue instead, since world.Events would otherwise
+    // look permanently empty from the first tick.
+    bool IsFinished(SimWorld world) => world.Events.IsEmpty;
 }

--- a/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresScenario.cs
+++ b/AnoMech/Scenarios/Umad/P5Exaflares/UmadP5ExaflaresScenario.cs
@@ -112,6 +112,11 @@ public sealed class UmadP5ExaflaresScenario : IScenario
         timeline.Add(30.0f, DespawnAll);
     }
 
+    // The whole mechanic lives on the private `timeline`, not world.Events (see the class
+    // header comment), so Game's default IsFinished (world.Events.IsEmpty) would read true
+    // from the first tick. Watch the real queue instead.
+    public bool IsFinished(SimWorld world) => timeline.IsEmpty;
+
     public void Tick(float delta, float elapsed)
     {
         // Advance the timeline by real wall time, capping pause/hitch gaps so a freeze can't

--- a/AnoMech/Windows/MainWindow.cs
+++ b/AnoMech/Windows/MainWindow.cs
@@ -266,6 +266,13 @@ public unsafe class MainWindow : Window, IDisposable
 
         var god = game.GodMode;
         if (ImGui.Checkbox("God mode", ref god)) game.GodMode = god;
+        ImGui.SameLine();
+        var autoRestart = game.AutoRestart;
+        if (ImGui.Checkbox("Auto-restart", ref autoRestart)) game.AutoRestart = autoRestart;
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("Restart the same scenario immediately after a successful run. A death turns this back off.");
+        ImGui.SameLine();
+        ImGui.TextDisabled($"Streak: {game.MechanicStreak}");
 
 #if DEBUG
         debugMenu.DrawSpeedControl();


### PR DESCRIPTION
## Summary
- Tracks a single current streak: how many times in a row you've completed whatever scenario is active. Resets on any real (non-godmode) death and when you switch to a different scenario; restarting the *same* scenario (the normal way to extend it) does not reset it.
- Detection is fully generic, no per-scenario code required: `Game` infers a clean run from `IScenario.IsFinished` going true and staying true for a short settle window. The default implementation just checks `world.Events.IsEmpty`, which covers every scenario in the catalog except one.
- `UmadP5ExaflaresScenario` overrides `IsFinished`, since it schedules its whole mechanic on its own private `EventScheduler` (kept immune to `EventTimeScale` for real-time precision) rather than `world.Events`: the default would otherwise read "finished" from the very first tick.
- Correctness against false positives doesn't rely on any queue-draining/timing race: `Kill()` sets an explicit `deathOccurredThisRun` flag directly, independent of whichever queue a given scenario's `IsFinished` happens to watch, so a failed run can never be mistaken for a clean one regardless of scenario-specific timing.
- Optional **Auto-restart** toggle (off by default, next to the streak label in the main window): immediately reruns the same scenario with the same parameters after a streak-extending success, for hands-free repetition. Any real death turns it back off immediately, rather than restarting past a failure the death overlay/freeze exists to let you actually see.

## Test plan
- [x] `dotnet build` succeeds clean
- [x] Manually verified in-game: streak increments on a clean P5 Delta run, resets on death, resets on switching to a different scenario, does not reset on restarting the same one
- [x] Verified the Exaflares-specific bug this uncovered (streak incrementing almost immediately instead of at completion) is fixed by its `IsFinished` override
- [x] Auto-restart chaining across multiple successful runs, confirmed in-game