### PR TITLE
Add Ultimate Suppression Scenario

### DIFF
--- a/AnoMech/Core/Game/Game.cs
+++ b/AnoMech/Core/Game/Game.cs
@@ -18,6 +18,7 @@ using AnoMech.Scenarios.Umad.P3BlackHole;
 using AnoMech.Scenarios.Umad.P4KefkaSays;
 using AnoMech.Scenarios.Umad.P5Exaflares;
 using AnoMech.Scenarios.Uwu.UltimatePredation;
+using AnoMech.Scenarios.Uwu.UltimateSuppression;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using FFXIVClientStructs.FFXIV.Client.Game;
@@ -82,7 +83,8 @@ public sealed class Game : IDisposable
             new TopP5SigmaScenario(),
             new TopP5OmegaScenario(),
             new TopP6WaveCannon2Scenario(),
-            new UltimatePredationScenario()
+            new UltimatePredationScenario(),
+            new UltimateSuppressionScenario()
         };
 
         // Derive the zone tree from the flat registry (first-appearance order).

--- a/AnoMech/Core/Map/ZoneSession.cs
+++ b/AnoMech/Core/Map/ZoneSession.cs
@@ -197,8 +197,15 @@ public sealed unsafe class ZoneSession : IDisposable
                 // The Player could do something like jump, so to be extremely sure we are where we are supposed to, we set the Position and Rotation again.
                 SetLocalPlayerPosition(sessionSave.Position, sessionSave.Rotation);
                 condition->Occupied = false;
+
+                // TODO: this is here because of Suppression. Either define it as normal behaviour, or add an OnLeave method on Scenarios
                 condition->SufferingStatusAffliction = false;
                 condition->SufferingStatusAffliction2 = false;
+
+                if (Plugin.ObjectTable.LocalPlayer != null)
+                {
+                    PacketDispatcher.HandleActorControlPacket(Plugin.ObjectTable.LocalPlayer.EntityId, 54, 1, 0, 0, 0, 0, 0, 0, 0, 0xE0000000, false);
+                }
 
                 DisableFirewall();
             });

--- a/AnoMech/Core/Map/ZoneSession.cs
+++ b/AnoMech/Core/Map/ZoneSession.cs
@@ -197,6 +197,8 @@ public sealed unsafe class ZoneSession : IDisposable
                 // The Player could do something like jump, so to be extremely sure we are where we are supposed to, we set the Position and Rotation again.
                 SetLocalPlayerPosition(sessionSave.Position, sessionSave.Rotation);
                 condition->Occupied = false;
+                condition->SufferingStatusAffliction = false;
+                condition->SufferingStatusAffliction2 = false;
 
                 DisableFirewall();
             });

--- a/AnoMech/Core/SimObjects/SimCharacter.cs
+++ b/AnoMech/Core/SimObjects/SimCharacter.cs
@@ -38,8 +38,16 @@ public abstract unsafe class SimCharacter(Coordinates coordinates) : ISimObject,
 
     public GameObjectId GameObjectId => BattleCharaPtr == null ? default : BattleCharaPtr->GetGameObjectId();
     public float HitboxRadius => BattleCharaPtr == null ? 0f : BattleCharaPtr->HitboxRadius;
-    
-    
+
+    public uint EntityId
+    {
+        get
+        {
+            var obj = BattleCharaPtr;
+            return obj == null ? 0u : obj->EntityId;
+        }
+    }
+
     public virtual void Tick(float deltaSeconds)
     {
         var native = BattleCharaPtr;
@@ -96,7 +104,7 @@ public abstract unsafe class SimCharacter(Coordinates coordinates) : ISimObject,
     public void MoveTo(Vector3 target, float speed = 6f, float? finalRotation = null)
         => Movement.MoveTo(target, speed, finalRotation);
     public void MoveTo(Placement p) => MoveTo(p.Position);
-    protected void StopMoving() => Movement.Stop();
+    public void StopMoving() => Movement.Stop();
 
     public void Intercept(SimTether? tether, float margin = 3f) => Movement.Intercept(tether, margin);
 

--- a/AnoMech/Core/SimObjects/SimNpc.cs
+++ b/AnoMech/Core/SimObjects/SimNpc.cs
@@ -72,15 +72,6 @@ public unsafe class SimNpc : SimCharacter
         pendingDraw = true;
     }
 
-    public uint EntityId
-    {
-        get
-        {
-            var obj = BattleCharaPtr;
-            return obj == null ? 0u : obj->EntityId;
-        }
-    }
-
     public override void Tick(float deltaSeconds)
     {
         base.Tick(deltaSeconds);

--- a/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationScenario.cs
+++ b/AnoMech/Scenarios/Uwu/UltimatePredation/UltimatePredationScenario.cs
@@ -5,9 +5,7 @@ using System.Numerics;
 using AnoMech.Core.Game;
 using AnoMech.Core.Game.Ai;
 using AnoMech.Core.Game.Party;
-using AnoMech.Core.Map;
 using AnoMech.Core.SimObjects;
-using AnoMech.Pointers;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using FFXIVClientStructs.FFXIV.Client.Game;
@@ -16,7 +14,7 @@ using static AnoMech.Scenarios.Uwu.UwuConstants;
 
 namespace AnoMech.Scenarios.Uwu.UltimatePredation;
 
-public unsafe class UltimatePredationScenario : IScenario
+public class UltimatePredationScenario : IScenario
 {
     public string Name => "Ultimate Predation";
     public IPhase Phase => UwuZone.Ultima;
@@ -28,6 +26,7 @@ public unsafe class UltimatePredationScenario : IScenario
     private SimWorld world = null!;
     private SimParty party = null!;
 
+    private UwuUtils utils = null!;
     private UltimatePredationState state = null!;
 
     private SimEnemy? ultima;
@@ -36,15 +35,15 @@ public unsafe class UltimatePredationScenario : IScenario
 
     private SimEnemy?[] dummies = new SimEnemy?[13];
 
-    private List<Vector3> featherRainPositions = new();
-
     private SimEnemy? titan => state.ScenarioObjects.Titan;
+    private Func<SimEnemy?>[] featherRainDummies => [() => dummies[8], () => dummies[9], () => dummies[10], () => dummies[11], () => dummies[12]];
 
     public void Run(SimWorld world, int? selectedAi)
     {
         this.world = world;
         party = world.Party;
 
+        utils = new(world);
         state = new(settingsWindow.Overrides);
 
         if (selectedAi is { } idx && idx < AiStrats.Count)
@@ -93,8 +92,6 @@ public unsafe class UltimatePredationScenario : IScenario
                         0))
                 );
 
-            garuda?.AddStatusParam(StatusId.Woken, 0);
-
             ifrit = world.SpawnEnemy(
                 new EnemySpawnConfig(
                     BNpcBaseId: BNpcBaseId.Ifrit,
@@ -107,8 +104,6 @@ public unsafe class UltimatePredationScenario : IScenario
                         new Vector3(0, 0, 0),
                         0))
                 );
-
-            ifrit?.AddStatusParam(StatusId.Woken, 0);
 
             var titan = world.SpawnEnemy(
                 new EnemySpawnConfig(
@@ -123,12 +118,10 @@ public unsafe class UltimatePredationScenario : IScenario
                         0))
             );
 
-            titan?.AddStatusParam(StatusId.Woken, 0);
-
-            Awaken(ultima!, true);
-            Awaken(garuda!, false);
-            Awaken(ifrit!, false);
-            Awaken(titan!, false);
+            utils.Awaken(ultima, true);
+            utils.Awaken(garuda, false);
+            utils.Awaken(ifrit, false);
+            utils.Awaken(titan, false);
 
             state.ScenarioObjects.Titan = titan;
 
@@ -170,9 +163,9 @@ public unsafe class UltimatePredationScenario : IScenario
             world.SpawnEventObject(config);
         });
 
-        world.Events.Add(1, () => UwuUtils.UpdateArena(1));
+        world.Events.Add(1, () => utils.UpdateArena(1));
 
-        world.Events.Add(71.57f, () => UwuUtils.UpdateArena(2));
+        world.Events.Add(71.57f, () => utils.UpdateArena(2));
     }
 
     private void Ultima()
@@ -329,7 +322,7 @@ public unsafe class UltimatePredationScenario : IScenario
                 );
         });
 
-        Landslide(55.09f, 57.25f, 5, LandslideType.Ultima);
+        utils.LandslideLines(() => ultima, [() => dummies[5], () => dummies[6], () => dummies[7]], 55.09f, 57.25f, LandslideType.Ultima);
 
         world.Events.Add(57.25f, () => ultima?.NativeActionEffect(
             ActionId.LandslideUltima,
@@ -499,7 +492,7 @@ public unsafe class UltimatePredationScenario : IScenario
             animationTargetId: garuda.GameObjectId
             ));
 
-        world.Events.Add(21.53f, () => ResolveSnapshot(wickedWheelSnapshot, "Wicked Wheel"));
+        world.Events.Add(21.53f, () => utils.ResolveSnapshot(wickedWheelSnapshot, "Wicked Wheel"));
 
         // Wicked Tornado is handled by dummies[2]
         world.Events.Add(22.28f, () => dummies[2]?.SetPosition(garuda!.Placement()));
@@ -520,15 +513,11 @@ public unsafe class UltimatePredationScenario : IScenario
             wickedTornadoSnapshot = party.Find.InsideActionAoe(ActionId.WickedTornado, dummies[2]!.Placement(), size: 7); // 7 is ActionId.WickedWheelAwaken's EffectRange
         });
 
-        world.Events.Add(22.98f, () => ResolveSnapshot(wickedTornadoSnapshot, "Wicked Tornado"));
+        world.Events.Add(22.98f, () => utils.ResolveSnapshot(wickedTornadoSnapshot, "Wicked Tornado"));
 
-        world.Events.Add(25.25f, () =>
-        {
-            garuda?.PlayActionTimeline(ActionTimelineId.WarpStart2);
-            SetFeatherRainPositions();
-        });
+        world.Events.Add(25.25f, () => garuda?.PlayActionTimeline(ActionTimelineId.WarpStart2));
 
-        FeatherRain(26.72f, 27.70f);
+        utils.FeatherRain(featherRainDummies, 25.25f, 26.72f, 27.70f);
     }
 
     private void GarudaPost()
@@ -567,17 +556,12 @@ public unsafe class UltimatePredationScenario : IScenario
             ));
 
         // Technically these are for the Sisters. But adding it to their code section will duplicate the amount (10) that the actual fight uses (5), so it's kept here.
-        world.Events.Add(72.49f, SetFeatherRainPositions);
-        FeatherRain(73.91f, 74.87f); 
+        utils.FeatherRain(featherRainDummies, 72.49f, 73.91f, 74.87f);
 
-        // These are the proper Garuda Feather Rains
-        world.Events.Add(76.04f, () =>
-        {
-            garuda?.PlayActionTimeline(ActionTimelineId.WarpStart2);
-            SetFeatherRainPositions();
-        });
+        // These are actually from Garuda
+        world.Events.Add(76.04f, () => garuda?.PlayActionTimeline(ActionTimelineId.WarpStart2));
 
-        FeatherRain(77.46f, 78.41f);
+        utils.FeatherRain(featherRainDummies, 76.04f, 77.46f, 78.41f);
     }
 
     private void Ifrit()
@@ -612,7 +596,7 @@ public unsafe class UltimatePredationScenario : IScenario
             animationTargetId: ifrit.GameObjectId
             ));
 
-        world.Events.Add(20.69f, () => ResolveSnapshot(crimsonCycloneSnapshot, "Crimson Cyclone"));
+        world.Events.Add(20.69f, () => utils.ResolveSnapshot(crimsonCycloneSnapshot, "Crimson Cyclone"));
 
         CrimsonCycloneAwaken(Geometry.CrimsonCycloneAwakenPlacements[0], 11);
         CrimsonCycloneAwaken(Geometry.CrimsonCycloneAwakenPlacements[1], 12);
@@ -642,8 +626,14 @@ public unsafe class UltimatePredationScenario : IScenario
             targetId: ifrit.GameObjectId
             ));
 
-        Eruption(39.03f, 42.05f, 11);
-        Eruption(41.13f, 43.94f, 9);
+        IReadOnlyList<SimCharacter> eruptionBaits = null!;
+        world.Events.Add(39.03f, () => eruptionBaits = party.Find.FarestN(ifrit!.Position, 2));
+        utils.EruptionPuddle(() => dummies[11], () => eruptionBaits[0], 39.03f, 42.05f);
+        utils.EruptionPuddle(() => dummies[12], () => eruptionBaits[1], 39.03f, 42.05f);
+
+        world.Events.Add(41.13f, () => eruptionBaits = party.Find.FarestN(ifrit!.Position, 2));
+        utils.EruptionPuddle(() => dummies[9], () => eruptionBaits[0], 41.13f, 43.94f);
+        utils.EruptionPuddle(() => dummies[10], () => eruptionBaits[1], 41.13f, 43.94f);
 
         world.Events.Add(41.59f, () => ifrit?.NativeActionEffect(
             ActionId.EruptionIfrit,
@@ -655,8 +645,13 @@ public unsafe class UltimatePredationScenario : IScenario
             animationTargetId: ifrit.GameObjectId
             ));
 
-        Eruption(43.02f, 46.15f, 11);
-        Eruption(45.15f, 48.13f, 9);
+        world.Events.Add(43.02f, () => eruptionBaits = party.Find.FarestN(ifrit!.Position, 2));
+        utils.EruptionPuddle(() => dummies[11], () => eruptionBaits[0], 43.02f, 46.15f);
+        utils.EruptionPuddle(() => dummies[12], () => eruptionBaits[1], 43.02f, 46.15f);
+
+        world.Events.Add(45.15f, () => eruptionBaits = party.Find.FarestN(ifrit!.Position, 2));
+        utils.EruptionPuddle(() => dummies[9], () => eruptionBaits[0], 45.15f, 48.13f);
+        utils.EruptionPuddle(() => dummies[10], () => eruptionBaits[1], 45.15f, 48.13f);
 
         // TODO: Actual Infernal Fetters logic
         world.Events.Add(46.94f, () => world.Tether(dps, ot, TetherId.InfernalFetters, 21, StatusId.InfernalFetters));
@@ -707,7 +702,7 @@ public unsafe class UltimatePredationScenario : IScenario
             targetId: titan.GameObjectId
             ));
 
-        Landslide(18.22f, 20.43f, 8, LandslideType.Normal);
+        utils.LandslideLines(() => titan, [() => dummies[8], () => dummies[9], () => dummies[10], () => dummies[11], () => dummies[12]], 18.22f, 20.43f, LandslideType.Normal);
 
         world.Events.Add(20.43f, () => titan?.NativeActionEffect(
             ActionId.LandslideTitan,
@@ -719,7 +714,7 @@ public unsafe class UltimatePredationScenario : IScenario
             animationTargetId: titan.GameObjectId
             ));
 
-        Landslide(20.43f, 22.48f, 3, LandslideType.Awaken);
+        utils.LandslideLines(() => titan, [() => dummies[3], () => dummies[4], () => dummies[5], () => dummies[6], () => dummies[7]], 20.43f, 22.48f, LandslideType.Awaken);
 
         world.Events.Add(25.50f, () => titan?.PlayActionTimeline(ActionTimelineId.WarpStart));
     }
@@ -781,7 +776,7 @@ public unsafe class UltimatePredationScenario : IScenario
                 );
         });
 
-        Landslide(54.45f, 56.50f, 8, LandslideType.Normal);
+        utils.LandslideLines(() => titan, [() => dummies[8], () => dummies[9], () => dummies[10], () => dummies[11], () => dummies[12]], 54.45f, 56.50f, LandslideType.Normal);
 
         world.Events.Add(56.50f, () => titan?.NativeActionEffect(
             ActionId.LandslideTitan,
@@ -793,7 +788,7 @@ public unsafe class UltimatePredationScenario : IScenario
             animationTargetId: titan.GameObjectId
             ));
 
-        Landslide(56.50f, 58.49f, 0, LandslideType.Awaken);
+        utils.LandslideLines(() => titan, [() => dummies[0], () => dummies[1], () => dummies[2], () => dummies[3], () => dummies[4]], 56.50f, 58.49f, LandslideType.Awaken);
 
         world.Events.Add(61.79f, () => titan?.NativeActionEffect(
             ActionId.Tumult,
@@ -868,12 +863,6 @@ public unsafe class UltimatePredationScenario : IScenario
         world.Events.Add(69.61f, () => titan?.PlayActionTimeline(ActionTimelineId.WarpStart));
     }
 
-    private void Awaken(SimEnemy enemy, bool isUltima)
-    {
-        enemy?.AddStatusParam(StatusId.Woken, isUltima ? 97 : 0);
-        TimelineContainerPointers.SetAnimationState(&enemy!.BattleCharaPtr->Timeline, 0, 1);
-    }
-
     private void RadiantPlume(Vector3 position, int dummyIndex)
     {
         world.Events.Add(49.05f, () => dummies[dummyIndex]?.NativeCast(
@@ -899,79 +888,7 @@ public unsafe class UltimatePredationScenario : IScenario
             position: position
             ));
 
-        world.Events.Add(53.61f, () => ResolveSnapshot(radiantPlumeSnapshot, "Radiant Plume"));
-    }
-
-    private void SetFeatherRainPositions()
-    {
-        featherRainPositions.Clear();
-        var players = RoleList.Random(party, 5);
-
-        for (int i = 0; i < 5; i++)
-        {
-            featherRainPositions.Add(players.Get(i)!.Position);
-        }
-    }
-
-    private void FeatherRain(float castOffset, float effectOffset)
-    {
-        world.Events.Add(castOffset, () =>
-        {
-            for (int i = 0; i < 5; i++)
-            {
-                var dummy = dummies[8 + i];
-
-                dummy?.SetPosition(
-                    new Placement(
-                        featherRainPositions[i],
-                        0
-                        ));
-
-                dummy?.NativeCast(
-                    ActionId.FeatherRain,
-                    ActionType.Action,
-                    0f,
-                    0.7f,
-                    false
-                    );
-            }
-        });
-
-        var featherRainSnapshots = new List<IReadOnlyList<SimCharacter>>();
-        world.Events.Add(castOffset + 0.7f, () =>
-        {
-            for (int i = 0; i < 5; i++)
-            {
-                var dummy = dummies[8 + i];
-                featherRainSnapshots.Add(party.Find.InsideActionAoe(ActionId.FeatherRain, dummy!.Placement()));
-            }
-        });
-
-        world.Events.Add(effectOffset, () =>
-        {
-            for (int i = 0; i < 5; i++)
-            {
-                var dummy = dummies[8 + i];
-
-                dummy?.NativeActionEffect(
-                    ActionId.FeatherRain,
-                    1.1f,
-                    (ushort)ActionId.FeatherRain,
-                    0,
-                    ActionType.Action,
-                    0,
-                    position: dummy.Position
-                    );
-            }
-        });
-
-        world.Events.Add(effectOffset + 0.2f, () =>
-        {
-            foreach (var featherRainSnapshot in featherRainSnapshots)
-            {
-                ResolveSnapshot(featherRainSnapshot, "Feather Rain");
-            }
-        });
+        world.Events.Add(53.61f, () => utils.ResolveSnapshot(radiantPlumeSnapshot, "Radiant Plume"));
     }
 
     private void GarudaSister(Placement placement, uint nameId)
@@ -1016,7 +933,7 @@ public unsafe class UltimatePredationScenario : IScenario
             animationTargetId: sister.GameObjectId
             ));
 
-        world.Events.Add(70.71f, () => ResolveSnapshot(wickedWheelSnapshot, "Wicked Wheel"));
+        world.Events.Add(70.71f, () => utils.ResolveSnapshot(wickedWheelSnapshot, "Wicked Wheel"));
 
         world.Events.Add(72.49f, () => sister?.PlayActionTimeline(ActionTimelineId.WarpStart2));
 
@@ -1049,180 +966,7 @@ public unsafe class UltimatePredationScenario : IScenario
             crimsonCycloneAwakenSnapshot = party.Find.InsideActionAoe(ActionId.CrimsonCycloneAwaken, dummy!.Placement());
         });
 
-        world.Events.Add(22.95f, () => ResolveSnapshot(crimsonCycloneAwakenSnapshot, "Crimson Cyclone (Awaken)"));
-    }
-
-    private void Eruption(float castOffset, float effectOffset, int dummyStartIndex)
-    {
-        var position1 = Vector3.Zero;
-        var position2 = Vector3.Zero;
-
-        world.Events.Add(castOffset, () =>
-        {
-            var baits = party.Find.FarestN(ifrit!.Position, 2);
-
-            position1 = baits[0].Position;
-            position2 = baits[1].Position;
-
-            dummies[dummyStartIndex]?.NativeCast(
-                ActionId.EruptionPuddle,
-                ActionType.Action,
-                0f,
-                2.7f,
-                false,
-                rotation: float.Pi,
-                position: position1
-                );
-
-            dummies[dummyStartIndex + 1]?.NativeCast(
-                ActionId.EruptionPuddle,
-                ActionType.Action,
-                0f,
-                2.7f,
-                false,
-                rotation: float.Pi,
-                position: position2
-                );
-        });
-
-        IReadOnlyList<SimCharacter> eruptionSnapshot1 = null!;
-        IReadOnlyList<SimCharacter> eruptionSnapshot2 = null!;
-        world.Events.Add(castOffset + 2.7f, () =>
-        {
-            eruptionSnapshot1 = party.Find.InsideActionAoe(ActionId.EruptionPuddle, new(position1, 0));
-            eruptionSnapshot2 = party.Find.InsideActionAoe(ActionId.EruptionPuddle, new(position2, 0));
-        });
-
-        world.Events.Add(effectOffset, () =>
-        {
-            dummies[dummyStartIndex]?.NativeActionEffect(
-                ActionId.EruptionPuddle,
-                0.1f,
-                (ushort)ActionId.EruptionPuddle,
-                0,
-                ActionType.Action,
-                0,
-                rotation: 0,
-                position: position1
-                );
-
-            dummies[dummyStartIndex + 1]?.NativeActionEffect(
-                ActionId.EruptionPuddle,
-                0.1f,
-                (ushort)ActionId.EruptionPuddle,
-                0,
-                ActionType.Action,
-                0,
-                rotation: 0,
-                position: position2
-                );
-        });
-
-        world.Events.Add(effectOffset + 0.66f, () =>
-        {
-            ResolveSnapshot(eruptionSnapshot1, "Eruption");
-            ResolveSnapshot(eruptionSnapshot2, "Eruption");
-        });
-    }
-
-    private void Landslide(float castOffset, float effectOffset, int dummyStartIndex, LandslideType type)
-    {
-        float[] rotationOffsets;
-        uint actionId;
-        float castTime;
-        float animationLock;
-
-        switch (type)
-        {
-            case LandslideType.Normal:
-                rotationOffsets = Geometry.TitanLandslideOffsets.ToArray();
-                actionId = ActionId.LandslideLine;
-                castTime = 1.9f;
-                animationLock = 2.1f;
-                break;
-            case LandslideType.Awaken:
-                rotationOffsets = Geometry.TitanLandslideAwakenOffsets.ToArray();
-                actionId = ActionId.LandslideAwaken;
-                castTime = 1.7f;
-                animationLock = 1.1f;
-                break;
-            case LandslideType.Ultima:
-                rotationOffsets = Geometry.UltimaLandslideOffsets.ToArray();
-                actionId = ActionId.LandslideLineUltima;
-                castTime = 1.9f;
-                animationLock = 1.1f;
-                break;
-            default:
-                throw new Exception($"[UltimatePredationScenario.Landslide] Unsupported LandslideType {type}");
-        }
-
-        world.Events.Add(castOffset, () =>
-        {
-            var enemy = type == LandslideType.Ultima ? ultima : titan;
-
-            for (int i = 0; i < rotationOffsets.Length; i++)
-            {
-                var dummy = dummies[dummyStartIndex + i];
-
-                dummy?.SetPosition(
-                    new Placement(
-                        enemy!.Position,
-                        enemy.Rotation + rotationOffsets[i]
-                        ));
-
-                dummy?.NativeCast(
-                    actionId,
-                    ActionType.Action,
-                    0f,
-                    castTime,
-                    false,
-                    targetId: dummy.GameObjectId
-                    );
-            }
-        });
-
-        var landslideSnapshots = new List<IReadOnlyList<SimCharacter>>();
-        world.Events.Add(castOffset + castTime, () =>
-        {
-            for (int i = 0; i < rotationOffsets.Length; i++)
-            {
-                var dummy = dummies[dummyStartIndex + i];
-                var snapshot = party.Find.InsideActionAoe(actionId, dummy!.Placement());
-                landslideSnapshots.Add(snapshot);
-            }
-        });
-
-        world.Events.Add(effectOffset, () =>
-        {
-            for (int i = 0; i < rotationOffsets.Length; i++)
-            {
-                var dummy = dummies[dummyStartIndex + i];
-
-                dummy?.NativeActionEffect(
-                    actionId,
-                    animationLock,
-                    (ushort)actionId,
-                    0,
-                    ActionType.Action,
-                    0,
-                    animationTargetId: dummy.GameObjectId
-                    );
-            }
-        });
-
-        world.Events.Add(effectOffset + 0.73f, () =>
-        {
-            var enemy = type == LandslideType.Ultima ? ultima : titan;
-
-            foreach (var landslideSnapshot in landslideSnapshots)
-            {
-                foreach (var character in landslideSnapshot)
-                {
-                    // TODO: "30" and "50" are from Titan EX, but doubled. Need to find the proper UWU values.
-                    (character as ISimPartyMember)?.Knockback(enemy!.Position, 30, 50);
-                }
-            }
-        });
+        world.Events.Add(22.95f, () => utils.ResolveSnapshot(crimsonCycloneAwakenSnapshot, "Crimson Cyclone (Awaken)"));
     }
 
     private void BombBoulder(float spawnOffset, float buryOffset, float castOffset, float effectOffset, float fadeOffset, float despawnOffset, Vector3 position)
@@ -1260,7 +1004,7 @@ public unsafe class UltimatePredationScenario : IScenario
             burySnapshot = party.Find.InsideActionAoe(ActionId.Bury, boulder!.Placement());
         });
 
-        world.Events.Add(buryOffset + 0.53f, () => ResolveSnapshot(burySnapshot, "Bury"));
+        world.Events.Add(buryOffset + 0.53f, () => utils.ResolveSnapshot(burySnapshot, "Bury"));
 
         world.Events.Add(castOffset, () => boulder?.NativeCast(
             ActionId.Burst,
@@ -1286,18 +1030,10 @@ public unsafe class UltimatePredationScenario : IScenario
             )
         );
 
-        world.Events.Add(effectOffset + 0.16f, () => ResolveSnapshot(burstSnapshot, "Burst"));
+        world.Events.Add(effectOffset + 0.16f, () => utils.ResolveSnapshot(burstSnapshot, "Burst"));
 
         world.Events.Add(fadeOffset, () => PacketDispatcher.HandleActorControlPacket(boulder!.EntityId, 607, boulder.EntityId, 1, 0, 100, 0, 0, 0, 0, 0xE0000000, false));
         world.Events.Add(despawnOffset, () => boulder?.Despawn());
-    }
-
-    private void ResolveSnapshot(IReadOnlyList<SimCharacter> snapshot, string dieCause)
-    {
-        foreach (var character in snapshot)
-        {
-            character.Die(dieCause);
-        }
     }
 
     private void ResolveSnapshotTankbuster(IReadOnlyList<SimCharacter> snapshot, string dieCause)
@@ -1311,10 +1047,5 @@ public unsafe class UltimatePredationScenario : IScenario
         }
     }
 
-    private enum LandslideType
-    {
-        Normal,
-        Awaken,
-        Ultima
-    }
+    
 }

--- a/AnoMech/Scenarios/Uwu/UltimateSuppression/UltimateSuppressionAi.cs
+++ b/AnoMech/Scenarios/Uwu/UltimateSuppression/UltimateSuppressionAi.cs
@@ -1,0 +1,225 @@
+using System.Linq;
+using System.Numerics;
+using AnoMech.Core.Game;
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.Game.Party;
+using AnoMech.Core.SimObjects;
+using static AnoMech.Scenarios.Uwu.UwuConstants;
+
+namespace AnoMech.Scenarios.Uwu.UltimateSuppression;
+
+public class UltimateSuppressionAi : IScenarioAi<UltimateSuppressionState>
+{
+    public string Name => "NAUR";
+
+    private static readonly Placement West = new(new(-18.5f, 0, 0), Geometry.LookAtCenterRotation[DirectionEnum.W]);
+    private UltimateSuppressionState state = null!;
+
+    public void Run(UltimateSuppressionState state, SimWorld world)
+    {
+        this.state = state;
+
+        var ai = new AiManager(world);
+
+        ai.Move(5f, SuppressionStart);
+        ai.Move(15f, Eruptions1, 1);
+        ai.Move(18f, Eruptions2);
+        ai.Move(18.5f, Eruptions3);
+        ai.Move(21f, Eruptions4);
+        ai.Move(23.25f, FeatherRain1);
+        ai.Move(25.25f, FeatherRain2);
+        ai.Move(26.75f, () => AiMove.Single(((ISimPartyMember)state.PlayerLightPillar!).Role, new(6, -5)));
+        ai.Move(29f, () => AiMove.Single(((ISimPartyMember)state.PlayerLightPillar!).Role, new(6.25f, 0)));
+        ai.Move(31f, () => AiMove.All(new(6.7f, 0)));
+        ai.Move(33f, () => AiMove.Single(PartyRole.MainTank, new(-4, -7)));
+        ai.Move(33.25f, Landslide1);
+        ai.Move(35.75f, Landslide2);
+        ai.Move(42f, () => AiMove.All(new(7, 5)));
+    }
+
+    private IAiMove SuppressionStart()
+    {
+        const int SpotCount = 6;
+        var fraction = 90 / (SpotCount - 1);
+        var spots = Enumerable.Range(0, SpotCount)
+            .Select(x => RotateSuppresionSpot(fraction * x))
+            .Shuffle()
+            .ToArray();
+
+        return AiMove.Create(
+            new(-6, 8),  // MT
+            new(-6, 8), // OT
+            spots[0], // H1
+            spots[1], // H2
+            spots[2], // M1
+            spots[3], // M2
+            spots[4], // R1
+            spots[5] // R2
+            ).NaturalOrder();
+    }
+
+    private IAiMove Eruptions1()
+    {
+        return AiMove.Create(
+            null, null, // Tanks
+            new(0, 0), // H1
+            new(0, 0), // H2
+            new(0, 0), // M1
+            new(0, 0), // M2
+            new(0, 0), // R1
+            new(0, 0) // R2
+            ).NaturalOrder();
+    }
+
+    private IAiMove Eruptions2()
+    {
+        return AiMove.Create(
+            null, null, // Tanks
+            new(2, 2), // Light Pillar
+            new(2, 2), // Mistral Song
+            new(2, 2), // Mistral Song
+            new(2, 2), // Eruption
+            new(2, 2), // Eruption
+            new(2, 2) // Gaol
+            )
+            .Assignments([
+                PartyRole.MainTank,
+                PartyRole.OffTank,
+                ((ISimPartyMember)state.PlayerLightPillar!).Role,
+                ((ISimPartyMember)state.PlayerMistralSongs[0]!).Role,
+                ((ISimPartyMember)state.PlayerMistralSongs[1]!).Role,
+                ((ISimPartyMember)state.PlayerEruptions[0]!).Role,
+                ((ISimPartyMember)state.PlayerEruptions[1]!).Role,
+                ((ISimPartyMember)state.PlayerGaol!).Role,
+            ]);
+    }
+
+    private IAiMove Eruptions3()
+    {
+        return AiMove.Create(
+            null, null, // Tanks
+            new(-8, 10), // Light Pillar
+            new(-8, 10), // Mistral Song
+            new(-8, 10), // Mistral Song
+            new(8, 8), // Eruption
+            new(8, 8), // Eruption
+            new(8, 8) // Gaol
+            )
+            .Assignments([
+                PartyRole.MainTank,
+                PartyRole.OffTank,
+                ((ISimPartyMember)state.PlayerLightPillar!).Role,
+                ((ISimPartyMember)state.PlayerMistralSongs[0]!).Role,
+                ((ISimPartyMember)state.PlayerMistralSongs[1]!).Role,
+                ((ISimPartyMember)state.PlayerEruptions[0]!).Role,
+                ((ISimPartyMember)state.PlayerEruptions[1]!).Role,
+                ((ISimPartyMember)state.PlayerGaol!).Role,
+            ]);
+    }
+
+    private IAiMove Eruptions4()
+    {
+        return AiMove.Create(
+            null, null, null, null, null,
+            new(12, -2), new(12, -2), // Eruption
+            null
+            )
+            .Assignments([
+                PartyRole.MainTank,
+                PartyRole.OffTank,
+                ((ISimPartyMember)state.PlayerLightPillar!).Role,
+                ((ISimPartyMember)state.PlayerMistralSongs[0]!).Role,
+                ((ISimPartyMember)state.PlayerMistralSongs[1]!).Role,
+                ((ISimPartyMember)state.PlayerEruptions[0]!).Role,
+                ((ISimPartyMember)state.PlayerEruptions[1]!).Role,
+                ((ISimPartyMember)state.PlayerGaol!).Role,
+            ]);
+    }
+
+    private IAiMove FeatherRain1()
+    {
+        var gaol = state.PlayerGaol!;
+        var gaolPos = new Vector2(gaol.Position.X, gaol.Position.Z);
+
+        return AiMove.Create(
+            gaolPos,  // MT
+            gaolPos, // OT
+            new(-12, -2), // Light Pillar
+            gaolPos, // Mistral Song
+            gaolPos, // Mistral Song
+            new(6, -5), // Eruption
+            new(6, -5), // Eruption
+            null // Gaol
+            )
+            .Assignments([
+                PartyRole.MainTank,
+                PartyRole.OffTank,
+                ((ISimPartyMember)state.PlayerLightPillar!).Role,
+                ((ISimPartyMember)state.PlayerMistralSongs[0]!).Role,
+                ((ISimPartyMember)state.PlayerMistralSongs[1]!).Role,
+                ((ISimPartyMember)state.PlayerEruptions[0]!).Role,
+                ((ISimPartyMember)state.PlayerEruptions[1]!).Role,
+                ((ISimPartyMember)gaol).Role,
+            ]);
+    }
+
+    private IAiMove FeatherRain2()
+    {
+        return AiMove.Create(
+            new(6, 4),  // MT
+            new(6, 4), // OT
+            new(-4, -7), // Light Pillar
+            new(6, 4), // Mistral Song
+            new(6, 4), // Mistral Song
+            new(6, 4), // Eruption
+            new(6, 4), // Eruption
+            null // Gaol
+            )
+            .Assignments([
+                PartyRole.MainTank,
+                PartyRole.OffTank,
+                ((ISimPartyMember)state.PlayerLightPillar!).Role,
+                ((ISimPartyMember)state.PlayerMistralSongs[0]!).Role,
+                ((ISimPartyMember)state.PlayerMistralSongs[1]!).Role,
+                ((ISimPartyMember)state.PlayerEruptions[0]!).Role,
+                ((ISimPartyMember)state.PlayerEruptions[1]!).Role,
+                ((ISimPartyMember)state.PlayerGaol!).Role,
+            ]);
+    }
+
+    private IAiMove Landslide1()
+    {
+        return AiMove.Create(
+            null, // MT
+            new(7, 5),// OT
+            new(7, 5), // H1
+            new(7, 5), // H2
+            new(7, 5), // M1
+            new(7, 5), // M2
+            new(7, 5), // R1
+            new(7, 5) // R2
+            ).NaturalOrder();
+    }
+
+    private IAiMove Landslide2()
+    {
+        return AiMove.Create(
+            null, // MT
+            new(6.7f, 0), // OT
+            new(6.7f, 0), // H1
+            new(6.7f, 0), // H2
+            new(6.7f, 0), // M1
+            new(6.7f, 0), // M2
+            new(6.7f, 0), // R1
+            new(6.7f, 0) // R2
+            ).NaturalOrder();
+    }
+
+    private static Vector2 RotateSuppresionSpot(float rotationDegrees)
+    {
+        var rot = float.DegreesToRadians(rotationDegrees);
+        var placement = West.RotateAroundOrigin(rot);
+
+        return placement.Position2;
+    }
+}

--- a/AnoMech/Scenarios/Uwu/UltimateSuppression/UltimateSuppressionScenario.cs
+++ b/AnoMech/Scenarios/Uwu/UltimateSuppression/UltimateSuppressionScenario.cs
@@ -1,0 +1,891 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Numerics;
+using AnoMech.Core.Game;
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.Game.Party;
+using AnoMech.Core.SimObjects;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.Game.Character;
+using FFXIVClientStructs.FFXIV.Client.Network;
+using static AnoMech.Scenarios.Uwu.UwuConstants;
+
+namespace AnoMech.Scenarios.Uwu.UltimateSuppression;
+
+public unsafe class UltimateSuppressionScenario : IScenario
+{
+    public string Name => "Ultimate Suppression";
+    public IPhase Phase => UwuZone.Ultima;
+    public IReadOnlyList<IScenarioAi> AiStrats => [new UltimateSuppressionAi()];
+    public void DrawSettings() => settingsWindow.Draw();
+
+    private readonly UltimateSuppressionSettingsWindow settingsWindow = new();
+
+    private SimWorld world = null!;
+    private SimParty party = null!;
+
+    private UwuUtils utils = null!;
+    private UltimateSuppressionState state = null!;
+
+    private SimEnemy? ultima;
+    private SimEnemy? garuda;
+    private SimEnemy? ifrit;
+    private SimEnemy? titan;
+
+    private SimEnemy? chirada;
+    private SimEnemy? suparna;
+
+    private SimEnemy?[] dummies = new SimEnemy?[13];
+
+    private bool razorPlumesDamage = false;
+    private Stopwatch razorPlumesRotate = new();
+    private Stopwatch razorPlumesBack = new();
+    private Dictionary<SimEnemy, Placement> razorPlumes = new();
+
+    public void Run(SimWorld world, int? selectedAi)
+    {
+        this.world = world;
+        party = world.Party;
+
+        utils = new(world);
+        state = new(party, settingsWindow.Overrides);
+
+        razorPlumesDamage = false;
+        razorPlumesRotate.Reset();
+        razorPlumesBack.Reset();
+        DespawnRazorPlumes();
+
+        if (selectedAi is { } idx && idx < AiStrats.Count)
+            ((IScenarioAi<UltimateSuppressionState>)AiStrats[idx]).Run(state, world);
+
+        Init();
+        Arena();
+        Ultima();
+        Garuda();
+        Ifrit();
+        Titan();
+    }
+
+    public void Tick(float delta, float elapsed)
+    {
+        if (razorPlumesRotate.IsRunning)
+        {
+            var fraction = float.Min((float)razorPlumesRotate.Elapsed.TotalSeconds / Duration.RazorPlumeRotation, 1);
+            var angle = fraction * Geometry.RazorPlumeRotation;
+
+            foreach (var (razorPlume, placement) in razorPlumes)
+            {
+                var rotatedPlacement = placement.RotateAroundOrigin(angle);
+                razorPlume!.SetPosition(rotatedPlacement);
+            }
+        }
+        else if (razorPlumesBack.IsRunning)
+        {
+            var fraction = float.Min((float)razorPlumesBack.Elapsed.TotalSeconds / Duration.RazorPlumeBack, 1);
+            var distance = fraction * Geometry.RazorPlumeBackDistance;
+
+            foreach (var (razorPlume, placement) in razorPlumes)
+            {
+                var movedPlacement = placement.MoveForward(-distance);
+                razorPlume!.SetPosition(movedPlacement.Position);
+            }
+        }
+
+        if (razorPlumesDamage)
+        {
+            foreach (var (razorPlume, placement) in razorPlumes)
+            {
+                // TODO: Eyeballed Radius
+                foreach (var character in party.Find.InsideCircle(razorPlume.Position, 2))
+                {
+                    character.Die("Razor Plume");
+                }
+            }
+        }
+    }
+
+    private void Init()
+    {
+        world.Events.Add(0, () =>
+        {
+            ultima = world.SpawnEnemy(
+                new EnemySpawnConfig(
+                    BNpcBaseId: BNpcBaseId.UltimaWeapon,
+                    NameId: BNpcNameId.UltimaWeapon,
+                    Level: 70,
+                    Targetable: true,
+                    EnemyList: EnemyListMode.Always,
+                    IsVisible: true,
+                    Placement: new Placement(
+                        new Vector3(0, 0, -10),
+                        0),
+                    InitialModeAttributeFlags: 0x11)
+                );
+
+            garuda = world.SpawnEnemy(
+                new EnemySpawnConfig(
+                    BNpcBaseId: BNpcBaseId.Garuda,
+                    NameId: BNpcNameId.Garuda,
+                    Level: 70,
+                    Targetable: false,
+                    EnemyList: EnemyListMode.Never,
+                    IsVisible: false,
+                    Placement: new Placement(
+                        new Vector3(0, 0, 0),
+                        0))
+                );
+
+            garuda?.AddStatusParam(StatusId.Woken, 0);
+
+            ifrit = world.SpawnEnemy(
+                new EnemySpawnConfig(
+                    BNpcBaseId: BNpcBaseId.Ifrit,
+                    NameId: BNpcNameId.Ifrit,
+                    Level: 70,
+                    Targetable: false,
+                    EnemyList: EnemyListMode.Never,
+                    IsVisible: false,
+                    Placement: new Placement(
+                        new Vector3(0, 0, 0),
+                        0))
+                );
+
+            ifrit?.AddStatusParam(StatusId.Woken, 0);
+
+            titan = world.SpawnEnemy(
+                new EnemySpawnConfig(
+                    BNpcBaseId: BNpcBaseId.Titan,
+                    NameId: BNpcNameId.Titan,
+                    Level: 70,
+                    Targetable: false,
+                    EnemyList: EnemyListMode.Never,
+                    IsVisible: false,
+                    Placement: new Placement(
+                        new Vector3(0, 0, 0),
+                        0))
+            );
+
+            titan?.AddStatusParam(StatusId.Woken, 0);
+
+            utils.Awaken(ultima!, true);
+            utils.Awaken(garuda!, false);
+            utils.Awaken(ifrit!, false);
+            utils.Awaken(titan!, false);
+
+            chirada = world.SpawnEnemy(
+                new EnemySpawnConfig(
+                    BNpcBaseId: BNpcBaseId.SuparnaChirada,
+                    NameId: BNpcNameId.Chirada,
+                    Level: 70,
+                    Targetable: false,
+                    EnemyList: EnemyListMode.Never,
+                    IsVisible: false,
+                    Placement: new Placement(
+                        new Vector3(0, 0, 0),
+                        0))
+            );
+
+            suparna = world.SpawnEnemy(
+                new EnemySpawnConfig(
+                    BNpcBaseId: BNpcBaseId.SuparnaChirada,
+                    NameId: BNpcNameId.Suparna,
+                    Level: 70,
+                    Targetable: false,
+                    EnemyList: EnemyListMode.Never,
+                    IsVisible: false,
+                    Placement: new Placement(
+                        new Vector3(0, 0, 0),
+                        0))
+            );
+
+            for (int i = 0; i < dummies.Length; i++)
+            {
+                dummies[i] = world.SpawnEnemy(
+                new EnemySpawnConfig(
+                    BNpcBaseId: BNpcBaseId.Dummy,
+                    NameId: BNpcNameId.Dummy,
+                    Level: 70,
+                    Targetable: false,
+                    EnemyList: EnemyListMode.Never,
+                    IsVisible: true,
+                    Placement: new Placement(
+                        new Vector3(0, 0, 0),
+                        0)
+                    )
+                );
+            }
+
+            var mt = party.Get(PartyRole.MainTank);
+            var healer = party.Get(state.Rng.NextHealerRole());
+
+            mt?.AddStatus(StatusId.ThermalLow);
+            healer?.AddStatus(StatusId.ThermalLow);
+        });
+    }
+
+    private void Arena()
+    {
+        world.Events.Add(0, () =>
+        {
+            var config = new EventObjectSpawnConfig
+            {
+                EObjId = 2007457,
+                Placement = new(new(0.16f, 0, 1.4434f), 0),
+                ObjectIndex = 1,
+                TargetableStatus = 5,
+                EntityId = 0x4000829C,
+                LayoutId = 7538913,
+                GimmickId = 7538258,
+                TimelineState = 1
+            };
+
+            world.SpawnEventObject(config);
+        });
+
+        world.Events.Add(1, () =>
+        {
+            utils.UpdateArena(1);
+            utils.UpdateArena(2);
+        });
+
+        world.Events.Add(24.70f, () => utils.UpdateArena(4));
+    }
+
+    private void Ultima()
+    {
+        var getUltima = () => ultima;
+
+        // ActionId.UltimateSuppression is Animation Only
+        utils.Cast(getUltima,
+            2.50f, new() { ActionId = ActionId.UltimateSuppression, ActionType = ActionType.Action, OmenDelay = 0f, CastTime = 2.7f, Interruptible = false },
+            5.47f, new() { ActionId = ActionId.UltimateSuppression, AnimationLock = 4.5f, SpellId = (ushort)ActionId.UltimateSuppression, AnimationVariaton = 0, ActionType = ActionType.Action, Flags = 0 },
+            new() { CastTarget = getUltima, ActionEffectAnimationTarget = getUltima });
+
+        world.Events.Add(10.13f, () =>
+        {
+            ultima?.SetTargetable(false);
+            ultima?.PlayActionTimeline(ActionTimelineId.WarpStart);
+        });
+
+        world.Events.Add(12.15f, () => ultima?.SetPosition(
+             new Placement(
+                 new Vector3(13.7f, 0f, -13.7f),
+                 float.DegreesToRadians(-45f)
+             )));
+
+        world.Events.Add(12.37f, () => ultima?.PlayActionTimeline(ActionTimelineId.WarpEnd));
+
+        // ActionId.LightPillarUltima is Animation Only. Actual AOEs are handled in the LightPillar calls
+        utils.Cast(getUltima,
+            20.55f, new() { ActionId = ActionId.LightPillarUltima, ActionType = ActionType.Action, OmenDelay = 0f, CastTime = 1.7f, Interruptible = false },
+            22.57f, new() { ActionId = ActionId.LightPillarUltima, AnimationLock = 2.1f, SpellId = (ushort)ActionId.LightPillarUltima, AnimationVariaton = 0, ActionType = ActionType.Action, Flags = 0 },
+            new() { CastTarget = getUltima, ActionEffectAnimationTarget = getUltima });
+
+        AetherochemicalLaser(() => ultima, 24.70f, 27.55f);
+
+        LightPillar(() => dummies[5], 24.70f, 25.64f, true);
+        LightPillar(() => dummies[4], 25.64f, 26.60f);
+        LightPillar(() => dummies[10], 26.60f, 27.55f);
+        LightPillar(() => dummies[9], 27.55f, 28.71f);
+
+        AetherochemicalLaser(() => ultima, 28.71f, 31.60f);
+
+        LightPillar(() => dummies[10], 28.71f, 29.68f);
+        LightPillar(() => dummies[12], 29.68f, 30.65f);
+
+        AetherochemicalLaser(() => ultima, 32.84f, 35.78f);
+
+        // ActionId.TankPurge is Animation Only (TODO for more fleshed out damage logic?)
+        utils.Cast(getUltima,
+            40.03f, new() { ActionId = ActionId.TankPurge, ActionType = ActionType.Action, OmenDelay = 0f, CastTime = 3.7f, Interruptible = false },
+            43.88f, new() { ActionId = ActionId.TankPurge, AnimationLock = 2.1f, SpellId = (ushort)ActionId.TankPurge, AnimationVariaton = 0, ActionType = ActionType.Action, Flags = 0 },
+            new() { CastTarget = getUltima, ActionEffectAnimationTarget = getUltima });
+
+        world.Events.Add(46.10f, () => ultima?.PlayActionTimeline(ActionTimelineId.WarpStart));
+    }
+
+    private void Garuda()
+    {
+        var getGaruda = () => garuda;
+
+        world.Events.Add(12.15f, () =>
+        {
+            garuda?.SetPosition(
+                new Placement(
+                    new Vector3(-13.7f, 0f, -13.7f),
+                    float.DegreesToRadians(45f)
+                ));
+
+            chirada?.SetPosition(
+                new Placement(
+                    new Vector3(6f, 0f, 6f),
+                    float.DegreesToRadians(-135f)
+                ));
+
+            suparna?.SetPosition(
+                new Placement(
+                    new Vector3(-6f, 0f, -6f),
+                    float.DegreesToRadians(45f)
+                ));
+        });
+
+        world.Events.Add(12.37f, () =>
+        {
+            garuda?.SetVisible(true);
+            garuda?.PlayActionTimeline(ActionTimelineId.WarpEnd);
+
+            chirada?.SetVisible(true);
+            chirada?.PlayActionTimeline(ActionTimelineId.WarpEnd);
+
+            suparna?.SetVisible(true);
+            suparna?.PlayActionTimeline(ActionTimelineId.WarpEnd);
+        });
+
+        world.Events.Add(14.50f, () => garuda?.PlayActionTimeline(ActionTimelineId.RazorPlume));
+
+        world.Events.Add(15.48f, () =>
+        {
+            var playerMistral1 = state.PlayerMistralSongs[0]!;
+            var playerMistral2 = state.PlayerMistralSongs[1]!;
+
+            Lockon(playerMistral1, LockonId.MistralSong);
+            Lockon(playerMistral2, LockonId.MistralSong);
+        });
+
+        world.Events.Add(17.95f, () =>
+        {
+            var placement1 = new Placement(new(12, 0, 12), Geometry.LookAtCenterRotation[DirectionEnum.SE]);
+            razorPlumes.Add(RazorPlume(placement1)!, placement1);
+
+            var placement2 = new Placement(new(-12, 0, 12), Geometry.LookAtCenterRotation[DirectionEnum.SW]);
+            razorPlumes.Add(RazorPlume(placement2)!, placement2);
+
+            var placement3 = new Placement(new(12, 0, -12), Geometry.LookAtCenterRotation[DirectionEnum.NE]);
+            razorPlumes.Add(RazorPlume(placement3)!, placement3);
+
+            var placement4 = new Placement(new(-12, 0, -12), Geometry.LookAtCenterRotation[DirectionEnum.NW]);
+            razorPlumes.Add(RazorPlume(placement4)!, placement4);
+
+            razorPlumesDamage = true;
+        });
+
+        IReadOnlyList<SimCharacter> chiradaMistralSnapshot = null!;
+        IReadOnlyList<SimCharacter> suparnaMistralSnapshot = null!;
+
+        world.Events.Add(20.55f, () =>
+        {
+            chirada?.Face(state.PlayerMistralSongs[0]);
+            suparna?.Face(state.PlayerMistralSongs[1]);
+
+            chirada?.NativeActionEffect(
+                ActionId.MistralSongSuparnaChirada,
+                2.1f,
+                (ushort)ActionId.MistralSongSuparnaChirada,
+                0,
+                ActionType.Action,
+                0,
+                animationTargetId: chirada.GameObjectId
+                );
+
+            suparna?.NativeActionEffect(
+                ActionId.MistralSongSuparnaChirada,
+                2.1f,
+                (ushort)ActionId.MistralSongSuparnaChirada,
+                0,
+                ActionType.Action,
+                0,
+                animationTargetId: suparna.GameObjectId
+                );
+
+            // ActionId.MistralSongSuparnaChirada has a CastType of 6, which gets treated as a circle, so we manually check it as a Cone (Garuda's Mistral Song IS a Cone)
+            // EffectRange is 40.
+            chiradaMistralSnapshot = party.Find.InsideCone(chirada!.Placement(), MathF.PI / 6f, 40).OrderBy(x => Vector3.DistanceSquared(chirada!.Position, x.Position)).ToList();
+            suparnaMistralSnapshot = party.Find.InsideCone(suparna!.Placement(), MathF.PI / 6f, 40).OrderBy(x => Vector3.DistanceSquared(suparna!.Position, x.Position)).ToList();
+        });
+
+        var chiradaMistralHit = Vector3.Zero;
+        var suparnaMistralHit = Vector3.Zero;
+
+        world.Events.Add(20.81f, () =>
+        {
+            chiradaMistralHit = ResolveMistralSong(chiradaMistralSnapshot);
+            suparnaMistralHit = ResolveMistralSong(suparnaMistralSnapshot);
+        });
+
+        world.Events.Add(20.82f, () =>
+        {
+            garuda?.Face(party.GetRandom());
+            razorPlumesRotate.Start();
+        });
+
+        world.Events.Add(20.82f + Duration.RazorPlumeRotation, () =>
+        {
+            razorPlumesRotate.Stop();
+
+            foreach (var key in razorPlumes.Keys)
+            {
+                razorPlumes[key] = key.Placement();
+            }
+
+            razorPlumesBack.Start();
+        });
+
+        world.Events.Add(20.82f + Duration.RazorPlumeRotation + Duration.RazorPlumeBack, razorPlumesBack.Stop);
+
+        // ActionId.MistralSong is Animation Only (TODO: does this actually do damage outside the cone?)
+        utils.Cast(getGaruda,
+            20.82f, new() { ActionId = ActionId.MistralSong, ActionType = ActionType.Action, OmenDelay = 0f, CastTime = 1.7f, Interruptible = false },
+            22.82f, new() { ActionId = ActionId.MistralSong, AnimationLock = 1.8f, SpellId = (ushort)ActionId.MistralSong, AnimationVariaton = 0, ActionType = ActionType.Action, Flags = 0 },
+            new() { CastTarget = getGaruda, ActionEffectActionTarget = getGaruda });
+
+        world.Events.Add(22.57f, () =>
+        {
+            chirada?.PlayActionTimeline(ActionTimelineId.WarpStart2);
+            suparna?.PlayActionTimeline(ActionTimelineId.WarpStart2);
+        });
+
+        utils.FeatherRain([() => dummies[6], () => dummies[7], () => dummies[8], () => dummies[9], () => dummies[10]], 22.57f, 24.11f, 25.15f);
+
+        GreatWhirlwind(() => dummies[11], () => chiradaMistralHit, 23.81f, 26.60f);
+        GreatWhirlwind(() => dummies[12], () => suparnaMistralHit, 23.81f, 26.60f);
+
+        world.Events.Add(24.70f, () => garuda?.PlayActionTimeline(ActionTimelineId.WarpStart2));
+
+        utils.FeatherRain([() => dummies[0], () => dummies[1], () => dummies[2], () => dummies[3], () => dummies[5]], 24.70f, 26.10f, 27.05f);
+
+        world.Events.Add(30.67f, () => garuda?.PlayActionTimeline(ActionTimelineId.WarpEnd));
+
+        world.Events.Add(32.84f, () => state.MesohighTether = world.Tether(garuda, End.Passable(), TetherId.Mesohigh));
+
+        SimCharacter? tetherTarget = null;
+        var tetherHadThermalLow = false;
+
+        world.Events.Add(37.92f, () =>
+        {
+            state.MesohighTether!.Resolved = true;
+            tetherTarget = state.MesohighTether.B;
+
+            garuda?.NativeActionEffect(
+                ActionId.Mesohigh,
+                2.1f,
+                (ushort)ActionId.Mesohigh,
+                0,
+                ActionType.Action,
+                0,
+                animationTargetId: tetherTarget!.GameObjectId
+                );
+
+            tetherHadThermalLow = tetherTarget!.HasStatus(StatusId.ThermalLow);
+            tetherTarget.RemoveStatus(StatusId.ThermalLow);
+            state.MesohighTether.Despawn();
+        });
+
+        // TODO: I don't know if Mesohigh does any damage aside from the tether
+        world.Events.Add(38.75f, () =>
+        {
+            if (!tetherHadThermalLow)
+            {
+                tetherTarget!.Die("Mesohigh");
+            }
+        });
+
+        world.Events.Add(41.20f, () =>
+        {
+            garuda?.PlayActionTimeline(ActionTimelineId.WarpStart2);
+
+            foreach (var (razorPlume, _) in razorPlumes)
+            {
+                razorPlume?.NativeActionEffect(
+                    ActionId.Featherlance,
+                    2.1f,
+                    (ushort)ActionId.Featherlance,
+                    0,
+                    ActionType.Action,
+                    0,
+                    animationTargetId: razorPlume.GameObjectId
+                    );
+            }
+        });
+
+        utils.FeatherRain([() => dummies[8], () => dummies[9], () => dummies[10], () => dummies[11], () => dummies[12]], 41.20f, 42.47f, 43.43f);
+
+        world.Events.Add(42.97f, () =>
+        {
+            foreach (var (razorPlume, _) in razorPlumes)
+            {
+                PacketDispatcher.HandleActorControlPacket(razorPlume!.EntityId, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0xE0000000, false); // Death Animation
+                PacketDispatcher.HandleActorControlPacket(razorPlume!.EntityId, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0xE0000000, false); // Set Mode
+            }
+
+            razorPlumesDamage = false;
+        });
+
+        world.Events.Add(51.12f, () =>
+        {
+            foreach (var (razorPlume, _) in razorPlumes)
+            {
+                PacketDispatcher.HandleActorControlPacket(razorPlume!.EntityId, 39, 0, 0, 0, 0, 0, 0, 0, 0, 0xE0000000, false); // Fade-Out
+            }
+        });
+
+        world.Events.Add(52.87f, DespawnRazorPlumes);
+    }
+
+    private void Ifrit()
+    {
+        var getIfrit = () => ifrit;
+
+        world.Events.Add(12.15f, () => ifrit?.SetPosition(
+             new Placement(
+                 new Vector3(13.7f, 0f, 13.7f),
+                 float.DegreesToRadians(-135f)
+             )));
+
+        world.Events.Add(12.37f, () =>
+        {
+            ifrit?.SetVisible(true);
+            ifrit?.PlayActionTimeline(ActionTimelineId.WarpEnd);
+        });
+
+        // ActionId.EruptionIfrit is Animation Only
+        utils.Cast(getIfrit,
+            14.50f, new() { ActionId = ActionId.EruptionIfrit, ActionType = ActionType.Action, OmenDelay = 0f, CastTime = 2.2f, Interruptible = false },
+            17.00f, new() { ActionId = ActionId.EruptionIfrit, AnimationLock = 2.4f, SpellId = (ushort)ActionId.EruptionIfrit, AnimationVariaton = 0, ActionType = ActionType.Action, Flags = 0 },
+            new() { CastTarget = getIfrit, ActionEffectActionTarget = getIfrit });
+
+        utils.EruptionPuddle(() => dummies[10], () => state.PlayerEruptions[0], 14.50f, 17.51f);
+        utils.EruptionPuddle(() => dummies[11], () => state.PlayerEruptions[1], 14.50f, 17.51f);
+        utils.EruptionPuddle(() => dummies[12], () => state.PlayerGaol, 14.50f, 17.51f);
+
+        utils.EruptionPuddle(() => dummies[7], () => state.PlayerEruptions[0], 16.50f, 19.38f);
+        utils.EruptionPuddle(() => dummies[8], () => state.PlayerEruptions[1], 16.50f, 19.38f);
+        utils.EruptionPuddle(() => dummies[9], () => state.PlayerGaol, 16.50f, 19.38f);
+
+        utils.EruptionPuddle(() => dummies[11], () => state.PlayerEruptions[0], 18.42f, 21.32f);
+        utils.EruptionPuddle(() => dummies[12], () => state.PlayerEruptions[1], 18.42f, 21.32f);
+
+        world.Events.Add(19.38f, () => ifrit?.PlayActionTimeline(ActionTimelineId.WarpStart));
+
+        utils.EruptionPuddle(() => dummies[9], () => state.PlayerEruptions[0], 20.55f, 23.32f);
+        utils.EruptionPuddle(() => dummies[10], () => state.PlayerEruptions[1], 20.55f, 23.32f);
+
+        world.Events.Add(31.60f, () => ifrit?.PlayActionTimeline(ActionTimelineId.WarpEnd));
+
+        world.Events.Add(33.60f, () => Lockon(state.PlayerFlamingCrush, LockonId.FlamingCrush));
+
+        IReadOnlyList<SimCharacter> flamingCrushSnapshot = null!;
+        world.Events.Add(38.78f, () =>
+        {
+            ifrit?.NativeActionEffect(
+                ActionId.FlamingCrush,
+                2.1f,
+                (ushort)ActionId.FlamingCrush,
+                0,
+                ActionType.Action,
+                0,
+                animationTargetId: state.PlayerFlamingCrush!.GameObjectId
+                );
+
+            foreach (var character in party.AllMembers())
+            {
+                character.AddStatusParam(StatusId.AccursedFlame, 0, 3);
+            }
+
+            flamingCrushSnapshot = party.Find.InsideActionAoe(ActionId.FlamingCrush, state.PlayerFlamingCrush!.Placement());
+        });
+
+        world.Events.Add(39.51f, () =>
+        {
+            var count = flamingCrushSnapshot.Count;
+
+            if (count != 7)
+            {
+                var cause = $"Flaming Crush ({count}/7 players in Stack)";
+
+                foreach (var character in flamingCrushSnapshot)
+                {
+                    character.Die(cause);
+                }
+            }
+        });
+
+        world.Events.Add(41.00f, () => ifrit?.PlayActionTimeline(ActionTimelineId.WarpStart));
+    }
+
+    private void Titan()
+    {
+        var getTitan = () => titan;
+
+        world.Events.Add(12.15f, () => titan?.SetPosition(
+             new Placement(
+                 new Vector3(-13.7f, 0f, 13.7f),
+                 float.DegreesToRadians(135f)
+             )));
+
+        world.Events.Add(12.37f, () =>
+        {
+            titan?.SetVisible(true);
+            titan?.PlayActionTimeline(ActionTimelineId.WarpEnd);
+        });
+
+        world.Events.Add(16.50f, () => titan?.NativeActionEffect(
+            ActionId.RockThrow,
+            2.1f,
+            (ushort)ActionId.RockThrow,
+            0,
+            ActionType.Action,
+            0,
+            animationTargetId: state.PlayerGaol!.GameObjectId
+            ));
+
+        world.Events.Add(18.65f, () => titan?.PlayActionTimeline(ActionTimelineId.WarpStart));
+
+        world.Events.Add(21.32f, () =>
+        {
+            PacketDispatcher.HandleActorControlPacket(state.PlayerGaol!.EntityId, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0xE0000000, false); // Make Untargetable
+
+            state.PlayerGaol!.AddStatusParam(StatusId.Fetters, 0);
+            state.PlayerGaol.StopMoving();
+
+            if (state.PlayerGaol is SimPlayer player)
+            {
+                SetStun(true);
+            }
+        });
+
+        SimEnemy? graniteGaol = null;
+
+        world.Events.Add(22.82f, () => graniteGaol = world.SpawnEnemy(
+            new EnemySpawnConfig(
+                BNpcBaseId: BNpcBaseId.GraniteGaol,
+                NameId: BNpcNameId.GraniteGaol,
+                Level: 70,
+                Targetable: false,
+                EnemyList: EnemyListMode.Manual,
+                IsVisible: true,
+                Placement: new(state.PlayerGaol!.Position, 0)
+                )
+            )
+        );
+
+        // Unknown
+        world.Events.Add(23.32f, () => PacketDispatcher.HandleActorControlPacket(graniteGaol!.EntityId, 36, 1, 142, 0, 0, 0, 0, 0, 0, 0xE0000000, false));
+
+        world.Events.Add(23.54f, () =>
+        {
+            graniteGaol!.SetVisibleInEnemyList(true);
+            graniteGaol!.SetTargetable(true);
+
+            graniteGaol?.NativeCast(
+                ActionId.GraniteImpact,
+                ActionType.Action,
+                0f,
+                6.7f,
+                false,
+                targetId: graniteGaol.GameObjectId
+                );
+        });
+
+        world.Events.Add(30.67f, () => titan?.PlayActionTimeline(ActionTimelineId.WarpEnd));
+
+        // Gaol gets removed as soon as cast ends, to not give that much of an advantage to the player
+        world.Events.Add(30.24f, () =>
+        {
+            PacketDispatcher.HandleActorControlPacket(state.PlayerGaol!.EntityId, 54, 1, 0, 0, 0, 0, 0, 0, 0, 0xE0000000, false); // Make Targetable
+
+            state.PlayerGaol!.RemoveStatus(StatusId.Fetters);
+
+            if (state.PlayerGaol is SimPlayer player)
+            {
+                SetStun(false);
+            }
+
+            ((Character*)graniteGaol!.BattleCharaPtr)->SetMode(CharacterModes.Dead, 0);
+            PacketDispatcher.HandleActorControlPacket(graniteGaol!.EntityId, 15, 540, 1, ActionId.GraniteImpact, 1, 0, 0, 0, 0, 0xE0000000, false); // Cast Interrupt
+            PacketDispatcher.HandleActorControlPacket(graniteGaol!.EntityId, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0xE0000000, false); // Death Animation
+        });
+
+        world.Events.Add(32.84f, () =>
+        {
+            var bait = party.GetRandom();
+            titan?.Face(bait);
+        });
+
+        // ActionId.LandslideTitan is Animation Only. Actual Landslides are handled at utils.LandslideLines calls
+        utils.Cast(getTitan,
+            32.84f, new() { ActionId = ActionId.LandslideTitan, ActionType = ActionType.Action, OmenDelay = 0f, CastTime = 1.9000001f, Interruptible = false },
+            35.07f, new() { ActionId = ActionId.LandslideTitan, AnimationLock = 4.1f, SpellId = (ushort)ActionId.LandslideTitan, AnimationVariaton = 0, ActionType = ActionType.Action, Flags = 0 },
+            new() { CastTarget = getTitan, ActionEffectActionTarget = getTitan });
+
+        utils.LandslideLines(() => titan, [() => dummies[8], () => dummies[9], () => dummies[10], () => dummies[11], () => dummies[12]], 32.84f, 35.07f, LandslideType.Normal);
+
+        utils.LandslideLines(() => titan, [() => dummies[3], () => dummies[4], () => dummies[5], () => dummies[6], () => dummies[7]], 35.07f, 37.22f, LandslideType.Awaken);
+
+        world.Events.Add(36.95f, () => PacketDispatcher.HandleActorControlPacket(graniteGaol!.EntityId, 39, 0, 0, 0, 0, 0, 0, 0, 0, 0xE0000000, false)); // Fade-Out
+
+        world.Events.Add(38.78f, () => graniteGaol?.Despawn());
+
+        world.Events.Add(41.20f, () => titan?.PlayActionTimeline(ActionTimelineId.WarpStart));
+    }
+
+    private void LightPillar(Func<SimEnemy?> getDummy, float castOffset, float effectOffset, bool direct = false)
+    {
+        const float Distance = 3f;
+        const float DistanceSquared = Distance * Distance;
+
+        var position = Vector3.Zero;
+
+        var castInfo = new UwuUtilsRecords
+        {
+            ActionId = ActionId.LightPillarCircle,
+            ActionType = ActionType.Action,
+            OmenDelay = 0f,
+            CastTime = 0.7f,
+            Interruptible = false
+        };
+
+        var actionEffectInfo = new ActionEffectInfo
+        {
+            ActionId = ActionId.LightPillarCircle,
+            AnimationLock = 0.1f,
+            SpellId = (ushort)ActionId.LightPillarCircle,
+            AnimationVariaton = 0,
+            ActionType = ActionType.Action,
+            Flags = 0
+        };
+
+        var dynamicInfo = new DynamicInfo
+        {
+            CastPosition = () => state.LightPillarPlacement.Position,
+            ActionEffectPosition = () => state.LightPillarPlacement.Position
+        };
+
+        world.Events.Add(castOffset, () =>
+        {
+            var playerPosition = state.PlayerLightPillar!.Position;
+
+            if (direct)
+            {
+                position = playerPosition;
+                state.LightPillarPlacement = new(position, 0);
+            }
+            else
+            {
+                var lightPillarPlacement = state.LightPillarPlacement;
+                if (Vector3.DistanceSquared(lightPillarPlacement.Position, playerPosition) < DistanceSquared)
+                {
+                    position = playerPosition;
+                }
+                else
+                {
+                    var rotated = lightPillarPlacement.Face(playerPosition);
+                    position = rotated.MoveForward(Distance).Position;
+                }
+                state.LightPillarPlacement = new(position, 0);
+            }
+        });
+
+        utils.Cast(getDummy, castOffset, castInfo, effectOffset, actionEffectInfo, dynamicInfo, 0.66f, snapshot => utils.ResolveSnapshot(snapshot, "Light Pillar"));
+    }
+
+    private void AetherochemicalLaser(Func<SimEnemy?> getEnemy, float castOffset, float effectOffset)
+    {
+        var laserActions = new uint[] { ActionId.AetherochemicalLaserCenter, ActionId.AetherochemicalLaserRight, ActionId.AetherochemicalLaserLeft };
+        var laserAction = state.Rng.NextObj(laserActions);
+
+        var castInfo = new UwuUtilsRecords
+        {
+            ActionId = laserAction,
+            ActionType = ActionType.Action,
+            CastTime = 2.7f
+        };
+
+        var actionEffectInfo = new ActionEffectInfo
+        {
+            ActionId = laserAction,
+            AnimationLock = 1.1f,
+            SpellId = (ushort)laserAction,
+            ActionType = ActionType.Action
+        };
+
+        var rotationOffset = laserAction switch
+        {
+            ActionId.AetherochemicalLaserRight => -45,
+            ActionId.AetherochemicalLaserLeft => 45,
+            _ => 0
+        };
+
+        var dynamicInfo = new DynamicInfo
+        {
+            CastRotation = () => getEnemy()!.Rotation + float.DegreesToRadians(rotationOffset),
+            CastTarget = getEnemy,
+            ActionEffectAnimationTarget = getEnemy
+        };
+
+        utils.Cast(getEnemy, castOffset, castInfo, effectOffset, actionEffectInfo, dynamicInfo, 0.66f, snapshot => utils.ResolveSnapshot(snapshot, "Aetherochemical Laser"));
+    }
+
+    private SimEnemy? RazorPlume(Placement placement)
+    {
+        var enemy = world.SpawnEnemy(
+            new EnemySpawnConfig(
+                BNpcBaseId: BNpcBaseId.RazorPlume,
+                NameId: BNpcNameId.RazorPlume,
+                Level: 70,
+                Targetable: false,
+                EnemyList: EnemyListMode.Never,
+                IsVisible: true,
+                Placement: placement,
+                InitialModeAttributeFlags: 0x0
+                )
+            );
+
+        return enemy;
+    }
+
+    private void DespawnRazorPlumes()
+    {
+        var plumes = razorPlumes.Keys.ToArray();
+        razorPlumes.Clear();
+
+        foreach (var plume in plumes)
+        {
+            plume?.Despawn();
+        }
+    }
+
+    private void GreatWhirlwind(Func<SimEnemy?> getDummy, Func<Vector3> getPosition, float castOffset, float effectOffset)
+    {
+        utils.Cast(getDummy,
+            castOffset, new() { ActionId = ActionId.GreatWhirlwind, ActionType = ActionType.Action, OmenDelay = 0f, CastTime = 2.7f, Interruptible = false },
+            effectOffset, new() { ActionId = ActionId.GreatWhirlwind, AnimationLock = 2.1f, SpellId = (ushort)ActionId.GreatWhirlwind, AnimationVariaton = 0, ActionType = ActionType.Action, Flags = 0 },
+            new() { CastPosition = getPosition, ActionEffectPosition = getPosition });
+    }
+
+    private void SetStun(bool value)
+    {
+        var condition = Conditions.Instance();
+        condition->SufferingStatusAffliction = value;
+        condition->SufferingStatusAffliction2 = value;
+    }
+
+    private void Lockon(SimCharacter? target, uint lockonId)
+    {
+        PacketDispatcher.HandleActorControlPacket(target!.EntityId, 34, lockonId, target!.GameObjectId.ObjectId, 0, 0, 0, 0, 0, 0, 0xE0000000, false);
+    }
+
+    private Vector3 ResolveMistralSong(IReadOnlyList<SimCharacter> snapshot)
+    {
+        var closest = snapshot[0];
+        var partyMember = (ISimPartyMember)closest;
+
+        if (partyMember != state.PlayerGaol && !partyMember.Role.IsTank())
+        {
+            closest.Die("Mistral Song");
+        }
+
+        return closest.Position;
+    }
+}

--- a/AnoMech/Scenarios/Uwu/UltimateSuppression/UltimateSuppressionScenario.cs
+++ b/AnoMech/Scenarios/Uwu/UltimateSuppression/UltimateSuppressionScenario.cs
@@ -491,6 +491,7 @@ public unsafe class UltimateSuppressionScenario : IScenario
             }
         });
 
+        List<IReadOnlyList<SimCharacter>> featherLanceSnapshot = new();
         world.Events.Add(41.20f, () =>
         {
             garuda?.PlayActionTimeline(ActionTimelineId.WarpStart2);
@@ -506,10 +507,17 @@ public unsafe class UltimateSuppressionScenario : IScenario
                     0,
                     animationTargetId: razorPlume.GameObjectId
                     );
+
+                featherLanceSnapshot.Add(party.Find.InsideActionAoe(ActionId.Featherlance, razorPlume!.Placement()));
             }
         });
 
         utils.FeatherRain([() => dummies[8], () => dummies[9], () => dummies[10], () => dummies[11], () => dummies[12]], 41.20f, 42.47f, 43.43f);
+
+        world.Events.Add(41.70f, () =>
+        {
+            utils.ResolveSnapshot(featherLanceSnapshot.SelectMany(x => x).ToList(), "Featherlance");
+        });
 
         world.Events.Add(42.97f, () =>
         {

--- a/AnoMech/Scenarios/Uwu/UltimateSuppression/UltimateSuppressionSettingsWindow.cs
+++ b/AnoMech/Scenarios/Uwu/UltimateSuppression/UltimateSuppressionSettingsWindow.cs
@@ -1,0 +1,42 @@
+using Dalamud.Bindings.ImGui;
+
+namespace AnoMech.Scenarios.Uwu.UltimateSuppression;
+
+public class UltimateSuppressionSettingsWindow
+{
+    public UltimateSuppressionStateOverrides Overrides { get; } = new();
+
+    public void Draw()
+    {
+        if (ImGui.Button("Auto"))
+        {
+            ResetAll();
+        }
+
+        if (SettingsGrid.Begin("##ultimatesuppression"))
+        {
+            DrawAssignment();
+            SettingsGrid.End();
+        }
+    }
+
+    private void DrawAssignment()
+    {
+        var v = Overrides.Assignment;
+        SettingsGrid.Row("Assignment (Non-Tank Only):");
+        if (ImGui.RadioButton("Auto##assignment", v == UltimateSuppressionAssignment.Auto)) Overrides.Assignment = UltimateSuppressionAssignment.Auto;
+        ImGui.SameLine();
+        if (ImGui.RadioButton("Light Pillar##assignment", v == UltimateSuppressionAssignment.LightPillar)) Overrides.Assignment = UltimateSuppressionAssignment.LightPillar;
+        ImGui.SameLine();
+        if (ImGui.RadioButton("Mistral Song##assignment", v == UltimateSuppressionAssignment.MistralSong)) Overrides.Assignment = UltimateSuppressionAssignment.MistralSong;
+        ImGui.SameLine();
+        if (ImGui.RadioButton("Eruption##assignment", v == UltimateSuppressionAssignment.Eruption)) Overrides.Assignment = UltimateSuppressionAssignment.Eruption;
+        ImGui.SameLine();
+        if (ImGui.RadioButton("Gaol##assignment", v == UltimateSuppressionAssignment.Gaol)) Overrides.Assignment = UltimateSuppressionAssignment.Gaol;
+    }
+
+    private void ResetAll()
+    {
+        Overrides.Assignment = UltimateSuppressionAssignment.Auto;
+    }
+}

--- a/AnoMech/Scenarios/Uwu/UltimateSuppression/UltimateSuppressionState.cs
+++ b/AnoMech/Scenarios/Uwu/UltimateSuppression/UltimateSuppressionState.cs
@@ -1,0 +1,45 @@
+using AnoMech.Core.Game;
+using AnoMech.Core.Game.Party;
+using AnoMech.Core.SimObjects;
+
+namespace AnoMech.Scenarios.Uwu.UltimateSuppression;
+
+public class UltimateSuppressionState
+{
+    public readonly Rng Rng = new();
+
+    public Placement LightPillarPlacement { get; set; } = new();
+
+    public SimCharacter? PlayerLightPillar = null!;
+    public SimCharacter?[] PlayerMistralSongs = new SimCharacter?[2];
+    public SimCharacter?[] PlayerEruptions = new SimCharacter?[2];
+    public SimCharacter? PlayerGaol = null!;
+    public SimCharacter? PlayerFlamingCrush = null!;
+
+    public SimTether? MesohighTether = null;
+
+    public UltimateSuppressionState(SimParty party, UltimateSuppressionStateOverrides overrides)
+    {
+        RoleList roles;
+        var doOverride = !party.PlayerRole.IsTank() && overrides.Assignment != UltimateSuppressionAssignment.Auto;
+
+        if (doOverride)
+        {
+            roles = RoleList.AllExcept(party, [PartyRole.MainTank, PartyRole.OffTank, party.PlayerRole]);
+        }
+        else
+        {
+            roles = RoleList.AllExcept(party, [PartyRole.MainTank, PartyRole.OffTank]);
+        }
+
+        var index = 0;
+
+        PlayerLightPillar = (doOverride && overrides.Assignment == UltimateSuppressionAssignment.LightPillar) ? party.Player : roles.Get(index++);
+        PlayerMistralSongs[0] = (doOverride && overrides.Assignment == UltimateSuppressionAssignment.MistralSong) ? party.Player : roles.Get(index++);
+        PlayerMistralSongs[1] = roles.Get(index++);
+        PlayerEruptions[0] = (doOverride && overrides.Assignment == UltimateSuppressionAssignment.Eruption) ? party.Player : roles.Get(index++);
+        PlayerEruptions[1] = roles.Get(index++);
+        PlayerGaol = (doOverride && overrides.Assignment == UltimateSuppressionAssignment.Gaol) ? party.Player : roles.Get(index++);
+        PlayerFlamingCrush = party.Get(Rng.NextDpsRole());
+    }
+}

--- a/AnoMech/Scenarios/Uwu/UltimateSuppression/UltimateSuppressionStateOverrides.cs
+++ b/AnoMech/Scenarios/Uwu/UltimateSuppression/UltimateSuppressionStateOverrides.cs
@@ -1,0 +1,15 @@
+namespace AnoMech.Scenarios.Uwu.UltimateSuppression;
+
+public enum UltimateSuppressionAssignment
+{
+    Auto,
+    LightPillar,
+    MistralSong,
+    Eruption,
+    Gaol
+}
+
+public class UltimateSuppressionStateOverrides
+{
+    public UltimateSuppressionAssignment Assignment { get; set; }
+}

--- a/AnoMech/Scenarios/Uwu/UwuConstants.cs
+++ b/AnoMech/Scenarios/Uwu/UwuConstants.cs
@@ -27,8 +27,10 @@ public class UwuConstants
     {
         public const uint Garuda = 8722;
         public const uint SuparnaChirada = 8723;
+        public const uint RazorPlume = 8724;
         public const uint Titan = 8727;
         public const uint BombBoulder = 8728;
+        public const uint GraniteGaol = 8729;
         public const uint Ifrit = 8730;
         public const uint UltimaWeapon = 8734;
         public const uint Dummy = 9020;
@@ -42,12 +44,18 @@ public class UwuConstants
         public const uint Garuda = 1644;
         public const uint Suparna = 1645;
         public const uint Chirada = 1646;
+        public const uint RazorPlume = 1647;
         public const uint Titan = 1801;
+        public const uint GraniteGaol = 1804;
         public const uint UltimaWeapon = 2137;
     }
 
     public class ActionId
     {
+        public const uint Featherlance = 11075;
+        public const uint GreatWhirlwind = 11073;
+        public const uint Mesohigh = 11081;
+        public const uint MistralSongSuparnaChirada = 11083;
         public const uint WickedWheel = 11084;
         public const uint FeatherRain = 11085;
         public const uint WickedWheelAwaken = 11086;
@@ -55,12 +63,14 @@ public class UwuConstants
         public const uint MistralShriek = 11092;
         public const uint EruptionIfrit = 11097;
         public const uint EruptionPuddle = 11098;
+        public const uint FlamingCrush = 11101;
         public const uint CrimsonCyclone = 11103;
         public const uint CrimsonCycloneAwaken = 11104;
         public const uint RadiantPlumePuddle = 11105;
         public const uint BoulderTitan = 11112;
         public const uint Bury = 11113;
         public const uint Burst = 11114;
+        public const uint RockThrow = 11115;
         public const uint LandslideLine = 11120;
         public const uint LandslideTitan = 11121;
         public const uint UltimatePredation = 11126;
@@ -71,17 +81,27 @@ public class UwuConstants
         public const uint RadiantPlumeUltima = 11133;
         public const uint LandslideUltima = 11134;
         public const uint LandslideLineUltima = 11135;
+        public const uint LightPillarUltima = 11138;
+        public const uint LightPillarCircle = 11139;
+        public const uint AetherochemicalLaserCenter = 11140;
+        public const uint AetherochemicalLaserRight = 11141;
+        public const uint AetherochemicalLaserLeft = 11142;
+        public const uint TankPurge = 11143;
+        public const uint MistralSong = 11150;
         public const uint Tumult = 11288;
         public const uint InfernalFetters = 11289;
         public const uint LandslideAwaken = 11298;
+        public const uint GraniteImpact = 11448;
         public const uint PostUltimatePredation1 = 11475;
         public const uint PostUltimatePredation2 = 11476;
         public const uint PostUltimatePredation3 = 11477;
         public const uint UltimateAnnihilation = 11596;
+        public const uint UltimateSuppression = 11597;
     }
 
     public class ActionTimelineId
     {
+        public const ushort RazorPlume = 1412;
         public const ushort WarpStart = 7737;
         public const ushort WarpStart2 = 7738;
         public const ushort WarpEnd = 7747;
@@ -89,13 +109,29 @@ public class UwuConstants
 
     public class StatusId
     {
+        public const ushort Fetters = 292;
         public const ushort InfernalFetters = 377;
+        public const ushort ThermalLow = 1525;
+        public const ushort AccursedFlame = 1527;
         public const ushort Woken = 1529;
     }
 
     public class TetherId
     {
+        public const ushort Mesohigh = 4;
         public const ushort InfernalFetters = 9;
+    }
+
+    public class LockonId
+    {
+        public const ushort MistralSong = 16;
+        public const ushort FlamingCrush = 117;
+    }
+
+    public class Duration
+    {
+        public const float RazorPlumeRotation = 17.95f;
+        public const float RazorPlumeBack = 1f;
     }
 
     public class Geometry
@@ -103,6 +139,8 @@ public class UwuConstants
         public const float ArenaRadius = 19.4f;
         public const float WickedTornadoOuterRadius = 20; // 20 is the EffectRange in the Action sheet
 
+        public static readonly float RazorPlumeRotation = float.DegreesToRadians(-450);
+        public static readonly float RazorPlumeBackDistance = 3.6f;
         public static readonly FrozenDictionary<DirectionEnum, float> LookAtCenterRotation;
         public static readonly FrozenDictionary<DirectionEnum, Placement> UltimaPlacements;
         public static readonly FrozenDictionary<DirectionEnum, Placement> GarudaPlacements;

--- a/AnoMech/Scenarios/Uwu/UwuUtils.cs
+++ b/AnoMech/Scenarios/Uwu/UwuUtils.cs
@@ -1,12 +1,300 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using AnoMech.Core.Game;
+using AnoMech.Core.SimObjects;
 using AnoMech.Helpers;
+using AnoMech.Pointers;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using static AnoMech.Scenarios.Uwu.UwuConstants;
 
 namespace AnoMech.Scenarios.Uwu;
 
-public static class UwuUtils
+public enum LandslideType
 {
-    public static void UpdateArena(byte value)
+    Normal,
+    Awaken,
+    Ultima
+}
+
+public unsafe class UwuUtils(SimWorld world)
+{
+    private readonly SimWorld world = world;
+
+    public void UpdateArena(byte value)
     {
         byte[] unionData = [value];
         InstanceContentDirectorHelper.SetDirectorData(1, 0, unionData, true);
+    }
+
+    public void Awaken(SimEnemy? enemy, bool isUltima)
+    {
+        enemy?.AddStatusParam(StatusId.Woken, isUltima ? 97 : 0);
+        TimelineContainerPointers.SetAnimationState(&enemy!.BattleCharaPtr->Timeline, 0, 1);
+    }
+
+    public void ResolveSnapshot(IReadOnlyList<SimCharacter> snapshot, string dieCause)
+    {
+        foreach (var character in snapshot)
+        {
+            if (character.HasStatus(StatusId.Fetters))
+            {
+                continue;
+            }
+
+            character.Die(dieCause);
+        }
+    }
+
+    public void Cast(Func<SimEnemy?> getEnemy,
+        float castOffset, UwuUtilsRecords castInfo, float effectOffset, ActionEffectInfo actionEffectInfo,
+        DynamicInfo dynamicInfo,
+        float resolveDelay = 0, Action<IReadOnlyList<SimCharacter>>? resolveAction = null)
+    {
+        world.Events.Add(castOffset, () =>
+        {
+            var enemy = getEnemy();
+
+            enemy?.NativeCast(
+                castInfo.ActionId,
+                castInfo.ActionType,
+                castInfo.OmenDelay,
+                castInfo.CastTime,
+                castInfo.Interruptible,
+                dynamicInfo.GetValue(dynamicInfo.CastRotation),
+                dynamicInfo.GetValue(dynamicInfo.CastPosition),
+                dynamicInfo.GetValue(dynamicInfo.CastTarget),
+                dynamicInfo.GetValue(dynamicInfo.CastBallistaTarget)
+                );
+        });
+
+        IReadOnlyList<SimCharacter> snapshot = null!;
+
+        if (resolveAction != null)
+        {
+            world.Events.Add(castOffset + castInfo.CastTime, () =>
+            {
+                var enemy = getEnemy();
+                Placement placement;
+
+                if (dynamicInfo.CastRotation != null && dynamicInfo.CastPosition != null)
+                {
+                    placement = new(dynamicInfo.CastPosition(), dynamicInfo.CastRotation());
+                }
+                else if (dynamicInfo.CastRotation != null)
+                {
+                    placement = new(enemy!.Position, dynamicInfo.CastRotation());
+                }
+                else if (dynamicInfo.CastPosition != null)
+                {
+                    placement = new(dynamicInfo.CastPosition(), enemy!.Rotation);
+                }
+                else
+                {
+                    placement = enemy!.Placement();
+                }
+
+                snapshot = world.Party.Find.InsideActionAoe(castInfo.ActionId, placement);
+            });
+        }
+
+        world.Events.Add(effectOffset, () =>
+        {
+            var enemy = getEnemy();
+
+            enemy?.NativeActionEffect(
+                actionEffectInfo.ActionId,
+                actionEffectInfo.AnimationLock,
+                actionEffectInfo.SpellId,
+                actionEffectInfo.AnimationVariaton,
+                actionEffectInfo.ActionType,
+                actionEffectInfo.Flags,
+                dynamicInfo.GetValue(dynamicInfo.ActionEffectRotation),
+                dynamicInfo.GetValue(dynamicInfo.ActionEffectPosition),
+                dynamicInfo.GetValue(dynamicInfo.ActionEffectAnimationTarget),
+                dynamicInfo.GetValue(dynamicInfo.ActionEffectActionTarget),
+                dynamicInfo.GetValue(dynamicInfo.ActionEffectBallistaTarget)
+                );
+        });
+
+        if (resolveAction != null)
+        {
+            world.Events.Add(effectOffset + resolveDelay, () => resolveAction(snapshot));
+        }
+    }
+
+    public void FeatherRain(Func<SimEnemy?>[] getDummies, float snapshotOffset, float castOffset, float effectOffset)
+    {
+        var positions = new List<Vector3>();
+
+        world.Events.Add(snapshotOffset, () => positions.AddRange(
+            RoleList.Random(world.Party, getDummies.Length).List
+            .Select(x => world.Party.Get(x)!.Position)));
+
+        var castInfo = new UwuUtilsRecords
+        {
+            ActionId = ActionId.FeatherRain,
+            ActionType = ActionType.Action,
+            CastTime = 0.7f
+        };
+
+        var actionEffectInfo = new ActionEffectInfo
+        {
+            ActionId = ActionId.FeatherRain,
+            AnimationLock = 1.1f,
+            SpellId = (ushort)ActionId.FeatherRain,
+            ActionType = ActionType.Action
+        };
+
+        for (int i = 0; i < getDummies.Length; i++)
+        {
+            var getDummy = getDummies[i];
+
+            var dynamicInfo = new DynamicInfo
+            {
+                ActionEffectPosition = () => getDummy()!.Position
+            };
+
+            // if "i" is used directly, then the value will be 5 when the Action is executed
+            var index = i;
+
+            world.Events.Add(castOffset, () =>
+            {
+                var dummy = getDummy();
+
+                dummy?.SetPosition(
+                    new Placement(
+                        positions[index],
+                        0
+                        ));
+            });
+
+            Cast(getDummy, castOffset, castInfo, effectOffset, actionEffectInfo, dynamicInfo, 0.2f, snapshot => ResolveSnapshot(snapshot, "Feather Rain"));
+        }
+    }
+
+    public void EruptionPuddle(Func<SimEnemy?> getDummy, Func<SimCharacter?> getBait, float castOffset, float effectOffset)
+    {
+        var baitPosition = Vector3.Zero;
+
+        var getBaitPosition = () => baitPosition;
+        var getPi = () => float.Pi;
+
+        world.Events.Add(castOffset, () =>
+        {
+            baitPosition = getBait()!.Position;
+        });
+
+        var castInfo = new UwuUtilsRecords
+        {
+            ActionId = ActionId.EruptionPuddle,
+            ActionType = ActionType.Action,
+            OmenDelay = 0f,
+            CastTime = 2.7f,
+            Interruptible = false
+        };
+
+        var actionEffectInfo = new ActionEffectInfo
+        {
+            ActionId = ActionId.EruptionPuddle,
+            AnimationLock = 0.1f,
+            SpellId = (ushort)ActionId.EruptionPuddle,
+            AnimationVariaton = 0,
+            ActionType = ActionType.Action,
+            Flags = 0
+        };
+
+        var dynamicInfo = new DynamicInfo
+        {
+            CastRotation = getPi,
+            CastPosition = getBaitPosition,
+            ActionEffectRotation = getPi,
+            ActionEffectPosition = getBaitPosition,
+        };
+
+        Cast(getDummy, castOffset, castInfo, effectOffset, actionEffectInfo, dynamicInfo, 0.66f, snapshot => ResolveSnapshot(snapshot, "Eruption"));
+    }
+
+    public void LandslideLines(Func<SimEnemy?> getEnemy, Func<SimEnemy?>[] getDummies, float castOffset, float effectOffset, LandslideType type)
+    {
+        float[] rotationOffsets;
+        uint actionId;
+        float castTime;
+        float animationLock;
+
+        switch (type)
+        {
+            case LandslideType.Normal:
+                rotationOffsets = Geometry.TitanLandslideOffsets.ToArray();
+                actionId = ActionId.LandslideLine;
+                castTime = 1.9f;
+                animationLock = 2.1f;
+                break;
+            case LandslideType.Awaken:
+                rotationOffsets = Geometry.TitanLandslideAwakenOffsets.ToArray();
+                actionId = ActionId.LandslideAwaken;
+                castTime = 1.7f;
+                animationLock = 1.1f;
+                break;
+            case LandslideType.Ultima:
+                rotationOffsets = Geometry.UltimaLandslideOffsets.ToArray();
+                actionId = ActionId.LandslideLineUltima;
+                castTime = 1.9f;
+                animationLock = 1.1f;
+                break;
+            default:
+                throw new Exception($"[UltimatePredationScenario.Landslide] Unsupported LandslideType {type}");
+        }
+
+        var castInfo = new UwuUtilsRecords
+        {
+            ActionId = actionId,
+            ActionType = ActionType.Action,
+            CastTime = castTime
+        };
+
+        var actionEffectInfo = new ActionEffectInfo
+        {
+            ActionId = actionId,
+            AnimationLock = animationLock,
+            SpellId = (ushort)actionId,
+            ActionType = ActionType.Action
+        };
+
+        for (int i = 0; i < getDummies.Length; i++)
+        {
+            var getDummy = getDummies[i];
+
+            var dynamicInfo = new DynamicInfo
+            {
+                CastTarget = getDummy,
+                ActionEffectAnimationTarget = getDummy
+            };
+
+            // if "i" is used directly, then the value will be 5 when the Action is executed
+            var index = i;
+
+            world.Events.Add(castOffset, () =>
+            {
+                var enemy = getEnemy();
+                var dummy = getDummy();
+
+                dummy?.SetPosition(
+                    new Placement(
+                        enemy!.Position,
+                        enemy.Rotation + rotationOffsets[index]
+                        ));
+            });
+
+            Cast(getDummy, castOffset, castInfo, effectOffset, actionEffectInfo, dynamicInfo, 0.73f, snapshot =>
+            {
+                foreach (var character in snapshot)
+                {
+                    // TODO: "30" and "50" are from Titan EX, but doubled. Need to find the proper UWU values.
+                    (character as ISimPartyMember)?.Knockback(getEnemy()!.Position, 30, 50);
+                }
+            });
+        }
     }
 }

--- a/AnoMech/Scenarios/Uwu/UwuUtilsRecords.cs
+++ b/AnoMech/Scenarios/Uwu/UwuUtilsRecords.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Numerics;
+using AnoMech.Core.SimObjects;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
+
+namespace AnoMech.Scenarios.Uwu;
+
+public record UwuUtilsRecords
+{
+    public uint ActionId { get; init; }
+    public ActionType ActionType { get; init; }
+    public float OmenDelay { get; init; }
+    public float CastTime { get; init; }
+    public bool Interruptible { get; init; }
+    public float? Rotation { get; init; }
+    public Vector3? Position { get; init; }
+    public GameObjectId? Target { get; init; }
+    public GameObjectId? BallistaTarget { get; init; }
+}
+
+public record ActionEffectInfo
+{
+    public uint ActionId { get; init; }
+    public float AnimationLock { get; init; }
+    public ushort SpellId { get; init; }
+    public byte AnimationVariaton { get; init; }
+    public ActionType ActionType { get; init; }
+    public byte Flags { get; init; }
+    public float? Rotation { get; init; }
+    public Vector3? Position { get; init; }
+    public GameObjectId? AnimationTarget { get; init; }
+    public GameObjectId? ActionTarget { get; init; }
+    public GameObjectId? BallistaTarget { get; init; }
+}
+
+public record DynamicInfo
+{
+    public Func<float>? CastRotation { get; init; }
+    public Func<Vector3>? CastPosition { get; init; }
+    public Func<float>? ActionEffectRotation { get; init; }
+    public Func<Vector3>? ActionEffectPosition { get; init; }
+    public Func<SimEnemy?>? CastTarget { get; init; }
+    public Func<SimEnemy?>? CastBallistaTarget { get; init; }
+    public Func<SimEnemy?>? ActionEffectAnimationTarget { get; init; }
+    public Func<SimEnemy?>? ActionEffectActionTarget { get; init; }
+    public Func<SimEnemy?>? ActionEffectBallistaTarget { get; init; }
+
+    public float? GetValue(Func<float>? func) => func != null ? func() : null;
+    public Vector3? GetValue(Func<Vector3>? func) => func != null ? func() : null;
+    public GameObjectId? GetValue(Func<SimEnemy?>? func) => func != null ? func()!.GameObjectId : null;
+}


### PR DESCRIPTION
This PR implements an **Ultimate Suppression** _(UWU)_ Scenario.

As with the _Ultimate Predation_ one ( #15 ), this was made using data from a **Duty Recorder Replay**.
And, since the same Scenario setup is shared, the _NAUR_ remarks stays.

Since there's some more heavy and complex PR opened at the moment, I've kept most of the changes to the Scenario itself. There is some logic that could be used outside (like the Gaol stun), which I'll revisit to re-implement properly once the project is more relaxed.

That being said, there is some few changes to the Core that had to be made for this Scenario:
- **SimNpc.EntityId** was moved to **SimCharacter**, since the logic is still valid and doesn't lock it behind a specific class.
- **SimCharacter.StopMoving()** is now public. Needed for the Gaol stun logic.
- **ZoneSession.Revert()** resets Status conditions, and makes the player targetable. This allows the player to exit the Scenario whenever, including when they're stunned inside the Gaol.
