### PR TITLE
Add UCOB P5 Exaflares scenario

### DIFF
--- a/AnoMech/Core/Game/Game.cs
+++ b/AnoMech/Core/Game/Game.cs
@@ -16,6 +16,7 @@ using AnoMech.Scenarios.Umad;
 using AnoMech.Scenarios.Umad.P2Forsaken;
 using AnoMech.Scenarios.Umad.P3BlackHole;
 using AnoMech.Scenarios.Umad.P4KefkaSays;
+using AnoMech.Scenarios.Ucob.P5Exaflares;
 using AnoMech.Scenarios.Umad.P5Exaflares;
 using AnoMech.Scenarios.Uwu.UltimatePredation;
 using Dalamud.Game.Text;
@@ -82,7 +83,8 @@ public sealed class Game : IDisposable
             new TopP5SigmaScenario(),
             new TopP5OmegaScenario(),
             new TopP6WaveCannon2Scenario(),
-            new UltimatePredationScenario()
+            new UltimatePredationScenario(),
+            new UcobP5ExaflaresScenario()
         };
 
         // Derive the zone tree from the flat registry (first-appearance order).

--- a/AnoMech/Core/Map/LayoutQuery.cs
+++ b/AnoMech/Core/Map/LayoutQuery.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using FFXIVClientStructs.FFXIV.Client.LayoutEngine;
 using FFXIVClientStructs.FFXIV.Client.LayoutEngine.Group;
@@ -37,6 +38,28 @@ internal static unsafe class LayoutQuery
             }
         }
         return count;
+    }
+
+    // Pointers to every layout instance (any type, not just SharedGroup) belonging to one LGB
+    // layer key, for MapController.SuppressLayer — a client-side zone load activates every
+    // layer at once (there's no real duty director picking the current phase's), so competing
+    // floor geometry from different phases can end up occupying the same space and z-fight.
+    public static List<nint> CollectLayerInstances(ushort layerKey)
+    {
+        var lw = LayoutWorld.Instance();
+        var result = new List<nint>();
+        if (lw == null || lw->ActiveLayout == null) return result;
+        foreach (var layerKv in lw->ActiveLayout->Layers)
+        {
+            var layer = layerKv.Item2.Value;
+            if (layer == null || layerKv.Item1 != layerKey) continue;
+            foreach (var instKv in layer->Instances)
+            {
+                var inst = instKv.Item2.Value;
+                if (inst != null) result.Add((nint)inst);
+            }
+        }
+        return result;
     }
 
     public static SharedGroupLayoutInstance* FindBySgbPath(string sgbPath)

--- a/AnoMech/Core/Map/MapController.cs
+++ b/AnoMech/Core/Map/MapController.cs
@@ -1,4 +1,5 @@
 using AnoMech.Helpers;
+using FFXIVClientStructs.FFXIV.Client.LayoutEngine;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
@@ -8,10 +9,13 @@ namespace AnoMech.Core.Map;
 // Unified entry point for zone loading and map effects. Owned by SimWorld as
 // world.Map. Zone and effects state are reset by Reset(); zone hooks are
 // released by Dispose().
-public sealed class MapController : IDisposable
+public sealed unsafe class MapController : IDisposable
 {
     private readonly MapEffects effects = new();
     private readonly ZoneSession zone = new();
+
+    // Layout instances forced inactive for the run's lifetime — see SuppressLayer.
+    private readonly List<nint> suppressedLayerInstances = new();
 
     // Collider-deactivation state. Zone-load is async (resources stream in over
     // several frames), so each pending drop re-tries DisableSpawnAreaColliders
@@ -53,11 +57,23 @@ public sealed class MapController : IDisposable
         zone.Revert(false);
         IsInInstance = false;
         pendingColliderDrops.Clear();
+        suppressedLayerInstances.Clear();
     }
+
+    // Forces one native LGB layer's instances inactive for as long as the zone stays loaded.
+    // Some zones' client-side load activates every layer at once (there is no real duty
+    // director selecting the current phase's), so competing geometry from different phases can
+    // render in the same space and z-fight. A one-shot SetActive doesn't stick — the engine
+    // reconciles it back within a frame or two — so this re-asserts every tick until Unload.
+    public void SuppressLayer(ushort layerKey)
+        => suppressedLayerInstances.AddRange(LayoutQuery.CollectLayerInstances(layerKey));
 
     // Per-frame poll. Called from SimWorld.Tick.
     internal void Tick()
     {
+        foreach (var ptr in suppressedLayerInstances)
+            ((ILayoutInstance*)ptr)->SetActive(false);
+
         for (int i = pendingColliderDrops.Count - 1; i >= 0; i--)
         {
             var drop = pendingColliderDrops[i];

--- a/AnoMech/Scenarios/Ucob/P5Exaflares/UcobP5ExaflaresAi.cs
+++ b/AnoMech/Scenarios/Ucob/P5Exaflares/UcobP5ExaflaresAi.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.SimObjects;
+
+namespace AnoMech.Scenarios.Ucob.P5Exaflares;
+
+public sealed class UcobP5ExaflaresAi : IScenarioAi<UcobP5ExaflaresState>
+{
+    public string Name => "Dodge";
+
+    private const float BlastClearance = 2f;
+    private const float DodgeSpeed = 7f;
+    private const float DecisionInterval = 0.75f;
+    private const float ArenaReach = 19f;
+    private const float MeleeRange = 6f;
+    private const float BotComfort = 2f;
+    private const float CrowdPenalty = 0.8f;
+    private const float MeleeWeight = 1f;
+    private const float TravelWeight = 0.35f;
+    private const float ImproveMargin = 4f;
+    private const float ArrivalEpsilon = 0.4f;
+    private const float BerthTravelPenalty = 0.05f;
+
+    private static readonly float[] PlanHorizons = [8f, 5f, 3f, 1.5f];
+    private static readonly float[] StandOffAlongLane = [-12f, -6f, 0f, 6f, 12f];
+
+    private UcobP5ExaflaresState state = null!;
+    private SimWorld world = null!;
+    private IReadOnlyList<Vector3> spots = [];
+    private readonly Vector3?[] committed = new Vector3?[8];
+    private readonly bool[] holding = new bool[8];
+
+    public void Run(UcobP5ExaflaresState stateParam, SimWorld worldParam)
+    {
+        state = stateParam;
+        world = worldParam;
+        spots = BuildLaneSpots();
+        Array.Clear(committed);
+        Array.Clear(holding);
+
+        var decisions = (int)MathF.Ceiling(
+            (state.LastHitAt - UcobP5ExaflaresState.FirstTelegraphAt) / DecisionInterval) + 1;
+        for (var i = 0; i < decisions; i++)
+        {
+            var at = UcobP5ExaflaresState.FirstTelegraphAt + i * DecisionInterval;
+            state.Timeline.Add(at, () => PlaceBotsOnSafeLanes(at));
+        }
+    }
+
+    private IReadOnlyList<Vector3> BuildLaneSpots()
+    {
+        var points = new List<Vector3>();
+        foreach (var offset in UcobP5ExaflaresState.LaneOffsets)
+            foreach (var along in StandOffAlongLane)
+            {
+                var spot = state.Lateral * offset + state.Travel * along;
+                if (IsInsideArena(spot)) points.Add(spot);
+            }
+        return points;
+    }
+
+    private void PlaceBotsOnSafeLanes(float now)
+    {
+        var live = TelegraphedHitsWithin(now, PlanHorizons[0]);
+        if (live.Count == 0) return;
+
+        var taken = new List<Vector3>(8);
+        foreach (var (slot, bot) in BotsMostAtRiskFirst(now, live))
+        {
+            var from = bot.Position;
+
+            if (committed[slot] is { } destination)
+            {
+                if (FlatDistance(from, destination) < ArrivalEpsilon) committed[slot] = null;
+                else if (IsRouteSafe(from, destination, now, live)) { taken.Add(destination); continue; }
+            }
+
+            var canHold = IsInsideArena(from) && IsRouteSafe(from, from, now, live);
+            var best = BestLaneSpot(from, now, taken, out var bestCost);
+            if (best is null && !canHold) best = WidestBerth(from, now);
+
+            if (best is not { } target || (canHold && SpotCost(from, from, taken) <= bestCost + ImproveMargin))
+            {
+                Hold(slot, bot, from, taken);
+                continue;
+            }
+
+            committed[slot] = target;
+            holding[slot] = false;
+            taken.Add(target);
+            bot.MoveTo(target, DodgeSpeed);
+        }
+    }
+
+    private void Hold(int slot, SimCharacter bot, Vector3 at, List<Vector3> taken)
+    {
+        committed[slot] = null;
+        taken.Add(at);
+        if (holding[slot]) return;
+        bot.MoveTo(at, DodgeSpeed);
+        holding[slot] = true;
+    }
+
+    private Vector3? BestLaneSpot(Vector3 from, float now, List<Vector3> taken, out float bestCost)
+    {
+        bestCost = float.MaxValue;
+        foreach (var horizon in PlanHorizons)
+        {
+            var threats = TelegraphedHitsWithin(now, horizon);
+            if (threats.Count == 0) return null;
+
+            Vector3? best = null;
+            foreach (var spot in spots)
+            {
+                if (!IsRouteSafe(from, spot, now, threats)) continue;
+                var cost = SpotCost(from, spot, taken);
+                if (cost >= bestCost) continue;
+                bestCost = cost;
+                best = spot;
+            }
+            if (best is not null) return best;
+        }
+        return null;
+    }
+
+    private Vector3? WidestBerth(Vector3 from, float now)
+    {
+        var threats = TelegraphedHitsWithin(now, PlanHorizons[^1]);
+        Vector3? best = null;
+        var bestScore = float.MinValue;
+        foreach (var spot in spots)
+        {
+            var score = RouteClearance(from, spot, now, threats) - BerthTravelPenalty * FlatDistance(from, spot);
+            if (score <= bestScore) continue;
+            bestScore = score;
+            best = spot;
+        }
+        return best;
+    }
+
+    private static float SpotCost(Vector3 from, Vector3 to, List<Vector3> taken)
+    {
+        var cost = MeleeWeight * MathF.Max(FlatDistance(Vector3.Zero, to), MeleeRange)
+                   + TravelWeight * FlatDistance(from, to);
+        foreach (var other in taken)
+        {
+            var gap = FlatDistance(other, to);
+            if (gap < BotComfort) cost += (BotComfort - gap) * CrowdPenalty;
+        }
+        return cost;
+    }
+
+    private IReadOnlyList<ExaflareHit> TelegraphedHitsWithin(float now, float horizon) =>
+        state.Hits.Where(h => h.KnownAt <= now && h.Time > now && h.Time <= now + horizon).ToList();
+
+    private IEnumerable<(int Slot, SimCharacter Bot)> BotsMostAtRiskFirst(float now, IReadOnlyList<ExaflareHit> threats)
+    {
+        var playerSlot = (int)world.Party.PlayerRole;
+        var bots = new List<(int, SimCharacter)>(7);
+        for (var slot = 0; slot < 8; slot++)
+        {
+            if (slot == playerSlot) continue;
+            if (world.Party.Get(slot) is { } bot && bot.IsAlive()) bots.Add((slot, bot));
+        }
+        return bots.OrderBy(b => RouteClearance(b.Item2.Position, b.Item2.Position, now, threats)).ToList();
+    }
+
+    private static bool IsRouteSafe(Vector3 from, Vector3 to, float now, IReadOnlyList<ExaflareHit> threats) =>
+        RouteClearance(from, to, now, threats) >= UcobP5ExaflaresState.HitRadius + BlastClearance;
+
+    private static float RouteClearance(Vector3 from, Vector3 to, float now, IReadOnlyList<ExaflareHit> threats)
+    {
+        var clearance = float.MaxValue;
+        foreach (var hit in threats)
+            clearance = MathF.Min(clearance, FlatDistance(PositionAt(from, to, now, hit.Time), hit.Position));
+        return clearance;
+    }
+
+    private static Vector3 PositionAt(Vector3 from, Vector3 to, float now, float when)
+    {
+        var travel = FlatDistance(from, to);
+        if (travel < 1e-3f) return from;
+        var covered = MathF.Max(0f, when - now) * DodgeSpeed;
+        return Vector3.Lerp(from, to, Math.Clamp(covered / travel, 0f, 1f));
+    }
+
+    private static bool IsInsideArena(Vector3 position) => FlatDistance(Vector3.Zero, position) <= ArenaReach;
+
+    private static float FlatDistance(Vector3 a, Vector3 b) =>
+        Vector2.Distance(new Vector2(a.X, a.Z), new Vector2(b.X, b.Z));
+}

--- a/AnoMech/Scenarios/Ucob/P5Exaflares/UcobP5ExaflaresScenario.cs
+++ b/AnoMech/Scenarios/Ucob/P5Exaflares/UcobP5ExaflaresScenario.cs
@@ -1,0 +1,163 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Numerics;
+using AnoMech.Core.Game;
+using AnoMech.Core.Game.Ai;
+using AnoMech.Core.SimObjects;
+using static AnoMech.Scenarios.Ucob.UcobConstants;
+
+namespace AnoMech.Scenarios.Ucob.P5Exaflares;
+
+// UCOB P5 "Exaflares": Bahamut Prime lays six parallel lanes across the arena, fired as three
+// pairs 3s apart, each lane erupting six times in 8y steps. Runs solo or with bots
+// (UcobP5ExaflaresAi). The geometry and timings are measured from a clear log; see
+// UcobP5ExaflaresState for the provenance.
+//
+// Each lane's first eruption is the release of its own arrow-omen cast (ExaflareFirst), so the
+// telegraph and hit 1 share one helper and cannot drift apart; the five follow-ups are instant
+// ExaflareRest casts from a helper spawned at each step. The flame itself is spawned by hand
+// (VfxPath.ExaflareEruption) because these actions carry no VFX the action effect could play. A hit snapshots who is standing in it
+// and holds the kill one application delay later, so the KO lands on the visible bloom rather
+// than on the invisible snapshot instant. Lingering flame is decorative: only the snapshot kills.
+//
+// The timeline runs on a scenario-local Stopwatch (`timeline`), not the engine's ms-truncated
+// UpdateDelta, so the arrow cast bars and the rolling hits stay locked together and ignore the
+// Speed buttons.
+public sealed class UcobP5ExaflaresScenario : IScenario
+{
+    public string Name => "Exaflares";
+    public IPhase Phase => UcobZone.P5;
+    public bool SupportsSolo => true;
+
+    public IReadOnlyList<IScenarioAi> AiStrats => [new UcobP5ExaflaresAi()];
+
+    public void DrawSettings() => settingsWindow.Draw();
+    private readonly UcobP5ExaflaresSettingsWindow settingsWindow = new();
+
+    // Snapshot -> kill application delay: sets only the instant a caught player dies, so the KO
+    // reads off the bloom instead of the snapshot. Same hold the UMAD exaflares use.
+    private const float KillDelay = 0.6f;
+    // Keep an eruption's helper alive this long so its flame isn't cut mid-animation.
+    private const float HitVfxSeconds = 3f;
+    private const float DespawnAfterLastHit = 4f;
+
+    private readonly EventScheduler timeline = new();
+    private readonly Stopwatch wallClock = new();
+    private double lastWall;
+    private const double FrameGapCapSeconds = 0.25; // skip pause / alt-tab / hitch frames
+
+    private UcobP5ExaflaresState state = null!;
+    private SimWorld world = null!;
+    private DamageSolver damage = null!;
+    private SimEnemy? bahamut;
+    private readonly List<SimEnemy> helpers = new();
+
+    public void Run(SimWorld worldParam, int? selectedAi)
+    {
+        world = worldParam;
+        damage = new DamageSolver(worldParam.Party);
+        helpers.Clear();
+
+        // Re-arm the scenario clock for this run (the scenario object is reused).
+        timeline.Clear();
+        wallClock.Restart();
+        lastWall = 0;
+
+        state = new UcobP5ExaflaresState(settingsWindow.Overrides, timeline);
+
+        // Bots schedule on the scenario `timeline` (after Clear, so their adds are absolute).
+        if (selectedAi is { } idx && idx < AiStrats.Count)
+            ((IScenarioAi<UcobP5ExaflaresState>)AiStrats[idx]).Run(state, world);
+
+        timeline.Add(0f, SpawnBahamut);
+        timeline.Add(UcobP5ExaflaresState.BossCastAt,
+            () => bahamut?.Cast(ActionId.Exaflare, castSeconds: UcobP5ExaflaresState.BossCastSeconds));
+        foreach (var line in state.Lines) LaunchLine(line);
+        timeline.Add(state.LastHitAt + DespawnAfterLastHit, DespawnAll);
+    }
+
+    public void Tick(float delta, float elapsed)
+    {
+        // Advance the timeline by real wall time, capping pause/hitch gaps so a freeze can't
+        // fast-forward it. This is what keeps the scenario drift-free.
+        var now = wallClock.Elapsed.TotalSeconds;
+        var wallDelta = now - lastWall;
+        lastWall = now;
+        if (wallDelta > 0 && wallDelta <= FrameGapCapSeconds)
+            timeline.Tick((float)wallDelta);
+    }
+
+    private void SpawnBahamut()
+    {
+        bahamut = world.SpawnEnemy(new EnemySpawnConfig(
+            BNpcBaseId: BNpcBaseId.BahamutPrime,
+            NameId: BNpcNameId.BahamutPrime,
+            Level: UcobConstants.Level,
+            Targetable: true,
+            EnemyList: EnemyListMode.Always,
+            IsVisible: true,
+            Placement: new Placement(Vector3.Zero, 0f),
+            ModelCharaId: ModelCharaId.GoldenBahamut));
+    }
+
+    // One lane. The arrow omen rides ExaflareFirst's own cast at the lane's first step and its
+    // release is that step's eruption; every later step is an instant cast from its own helper.
+    private void LaunchLine(ExaflareLine line)
+    {
+        SimEnemy? head = null;
+        timeline.Add(line.TelegraphAt, () =>
+        {
+            head = SpawnHelper(line.Start, line.Rotation);
+            head?.Cast(ActionId.ExaflareFirst, castSeconds: UcobP5ExaflaresState.TelegraphSeconds);
+            timeline.Add(UcobP5ExaflaresState.TelegraphSeconds + HitVfxSeconds, () => head?.Despawn());
+        });
+
+        for (var i = 0; i < line.Hits.Count; i++)
+        {
+            var hit = line.Hits[i];
+            var isFirst = i == 0;
+            timeline.Add(hit.Time, () =>
+            {
+                var actionId = isFirst ? ActionId.ExaflareFirst : ActionId.ExaflareRest;
+                SimEnemy? source = head;
+                if (!isFirst)
+                {
+                    source = SpawnHelper(hit.Position, line.Rotation);
+                    source?.Cast(actionId, castSeconds: 0f, animationLock: 0f);
+                    timeline.Add(HitVfxSeconds, () => source?.Despawn());
+                }
+                source?.AddVfx(VfxPath.ExaflareEruption, persistent: false);
+
+                var caught = damage.Resolve(source, actionId, [DamageType.Lethal], [], killTargets: false);
+                timeline.Add(KillDelay, () =>
+                {
+                    foreach (var c in caught)
+                        damage.ApplyDamage(c, 1f, actionId, "exaflare snapshot", lethal: true);
+                });
+            });
+        }
+    }
+
+    private SimEnemy? SpawnHelper(Vector3 position, float rotation)
+    {
+        var helper = world.SpawnEnemy(new EnemySpawnConfig(
+            BNpcBaseId: BNpcBaseId.Helper,
+            Level: UcobConstants.Level,
+            Targetable: false,
+            EnemyList: EnemyListMode.Never,
+            // Drawn on purpose: the eruption is an ActionTimeline on the helper, and a
+            // DisableDraw'd actor plays none. BNpcBase 0x18D6's ModelChara has no mesh,
+            // so "visible" still shows nothing but the fire.
+            IsVisible: true,
+            Placement: new Placement(position, rotation)));
+        if (helper != null) helpers.Add(helper);
+        return helper;
+    }
+
+    private void DespawnAll()
+    {
+        bahamut?.Despawn();
+        foreach (var helper in helpers) helper.Despawn();
+        helpers.Clear();
+    }
+}

--- a/AnoMech/Scenarios/Ucob/P5Exaflares/UcobP5ExaflaresSettingsWindow.cs
+++ b/AnoMech/Scenarios/Ucob/P5Exaflares/UcobP5ExaflaresSettingsWindow.cs
@@ -1,0 +1,27 @@
+using Dalamud.Bindings.ImGui;
+
+namespace AnoMech.Scenarios.Ucob.P5Exaflares;
+
+// Settings panel for the P5 exaflares scenario: pin or randomize the direction the lanes roll.
+// Mirrors TopP2PartySynergySettingsWindow's direction rows.
+public sealed class UcobP5ExaflaresSettingsWindow
+{
+    public UcobP5ExaflaresStateOverrides Overrides { get; } = new();
+
+    public void Draw()
+    {
+        if (ImGui.Button("Auto")) Overrides.Direction = null;
+
+        if (SettingsGrid.Begin("##ucobp5exaflares"))
+        {
+            SettingsGrid.Row("Rolls toward:");
+            if (ImGui.RadioButton("Auto##exadir", Overrides.Direction == null)) Overrides.Direction = null;
+            foreach (var d in Direction.All)
+            {
+                ImGui.SameLine();
+                if (ImGui.RadioButton($"{d.Name()}##exadir", Overrides.Direction == d)) Overrides.Direction = d;
+            }
+            SettingsGrid.End();
+        }
+    }
+}

--- a/AnoMech/Scenarios/Ucob/P5Exaflares/UcobP5ExaflaresState.cs
+++ b/AnoMech/Scenarios/Ucob/P5Exaflares/UcobP5ExaflaresState.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using AnoMech.Core.Game;
+
+namespace AnoMech.Scenarios.Ucob.P5Exaflares;
+
+// One rolling eruption: where it lands, when it lands, and when its lane arrow went up
+// (KnownAt): bots may only dodge what has already been telegraphed.
+public sealed record ExaflareHit(Vector3 Position, float Time, float KnownAt);
+
+// One lane of fire: six eruptions marching Advance yalms along Rotation, starting at Start.
+public sealed record ExaflareLine(Vector3 Start, float Rotation, float TelegraphAt, IReadOnlyList<ExaflareHit> Hits);
+
+// Per-run randomization plus the pattern it resolves to.
+//
+// Six parallel lanes cross the arena, all travelling the same way, spaced 8y apart at
+// perpendicular offsets -20/-12/-4/+4/+12/+20. Each lane erupts six times, 8y apart, from 20y
+// behind the arena to 20y past it. They fire as three pairs 3s apart, and which two lanes make
+// up a pair is randomized per set — so the dodge is "stand on a lane that has already burned,
+// or on one that is not in this pair", never "find the gap" (adjacent lanes are 8y apart and
+// each blast is 6y, so the lanes overlap).
+//
+// Every number here is measured from a clear log (fflogs r7bCpTZQJ2AdzVKH, fight 3, all four
+// Exaflare sets agree): lane offsets and spacing, the 20y start-back, 6 eruptions, 8y per step,
+// 1.47s between steps, 3.0s between pairs, the first pair's arrow going up 2.01s after the boss
+// starts its Exaflare cast, and the first eruption 3.97s after its own arrow.
+public sealed class UcobP5ExaflaresState
+{
+    public const float HitRadius = 6f;              // ExaflareFirst/Rest EffectRange
+    public const float Advance = 8f;
+    public const float RollInterval = 1.47f;
+    public const int HitsPerLine = 6;
+    public const float StartDistance = 20f;
+    public const float TelegraphSeconds = 3.97f;    // arrow omen up to its own release (the first eruption)
+
+    public const int PairCount = 3;
+    public const float PairInterval = 3f;
+    public const float BossCastAt = 3f;
+    public const float BossCastSeconds = 3.7f;
+    public const float FirstTelegraphAt = BossCastAt + 2.01f;
+
+    // Perpendicular offsets of the six lanes, in firing-agnostic order.
+    public static readonly IReadOnlyList<float> LaneOffsets = [-20f, -12f, -4f, 4f, 12f, 20f];
+
+    public Direction Direction { get; }
+
+    // Set axes: Travel is where the lanes roll, Lateral the axis the lane offsets sit on.
+    public Vector3 Travel { get; }
+    public Vector3 Lateral { get; }
+    public IReadOnlyList<ExaflareLine> Lines { get; }
+    public IReadOnlyList<ExaflareHit> Hits { get; }
+    public float LastHitAt { get; }
+
+    // The scenario's unscaled clock. Bots schedule their dodges on it rather than on the
+    // EventTimeScale-driven AiManager, so they stay locked to the fire.
+    public EventScheduler Timeline { get; }
+
+    private readonly Rng rng = new();
+
+    public UcobP5ExaflaresState(UcobP5ExaflaresStateOverrides overrides, EventScheduler timeline)
+    {
+        Timeline = timeline;
+        Direction = overrides.Direction ?? rng.NextDirection();
+
+        var theta = Direction.RadiansFromNorth;
+        var travel = new Vector3(MathF.Sin(theta), 0f, -MathF.Cos(theta));
+        var lateral = new Vector3(MathF.Cos(theta), 0f, MathF.Sin(theta));
+        Travel = travel;
+        Lateral = lateral;
+        // Placement rotation faces +Z at 0, so a compass bearing is its mirror.
+        var rotation = MathF.PI - theta;
+
+        var order = rng.Shuffle(LaneOffsets.ToArray()).ToList();
+        var lines = new List<ExaflareLine>(LaneOffsets.Count);
+        var hits = new List<ExaflareHit>(LaneOffsets.Count * HitsPerLine);
+        for (var i = 0; i < order.Count; i++)
+        {
+            var telegraphAt = FirstTelegraphAt + i / 2 * PairInterval;
+            var line = BuildLine(travel, lateral, rotation, order[i], telegraphAt);
+            lines.Add(line);
+            hits.AddRange(line.Hits);
+        }
+
+        Lines = lines;
+        Hits = hits;
+        LastHitAt = FirstTelegraphAt + (PairCount - 1) * PairInterval
+                    + TelegraphSeconds + (HitsPerLine - 1) * RollInterval;
+    }
+
+    private static ExaflareLine BuildLine(Vector3 travel, Vector3 lateral, float rotation, float offset, float telegraphAt)
+    {
+        var start = travel * -StartDistance + lateral * offset;
+        var hits = new List<ExaflareHit>(HitsPerLine);
+        for (var i = 0; i < HitsPerLine; i++)
+            hits.Add(new ExaflareHit(
+                start + travel * (Advance * i),
+                telegraphAt + TelegraphSeconds + i * RollInterval,
+                telegraphAt));
+
+        return new ExaflareLine(start, rotation, telegraphAt, hits);
+    }
+}

--- a/AnoMech/Scenarios/Ucob/P5Exaflares/UcobP5ExaflaresStateOverrides.cs
+++ b/AnoMech/Scenarios/Ucob/P5Exaflares/UcobP5ExaflaresStateOverrides.cs
@@ -1,0 +1,9 @@
+namespace AnoMech.Scenarios.Ucob.P5Exaflares;
+
+// User-controlled overrides for UcobP5ExaflaresState's randomized fields. Direction is where
+// the whole set of lanes travels TO; null leaves it randomized at scenario start. Which two
+// lanes fire together is always randomized, as it is in the fight.
+public sealed class UcobP5ExaflaresStateOverrides
+{
+    public Direction? Direction { get; set; }
+}

--- a/AnoMech/Scenarios/Ucob/UcobConstants.cs
+++ b/AnoMech/Scenarios/Ucob/UcobConstants.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Numerics;
+using AnoMech.Core.Game;
+
+namespace AnoMech.Scenarios.Ucob;
+
+public class UcobConstants
+{
+    public const byte Level = 70;
+    public const ushort ItemLevel = 345;
+
+    public static class Geometry
+    {
+        public const float ArenaRadius = 21f;
+    }
+
+    // "Aether Markers": A/B/C on the rim, D and 1-4 inside. Scenario-local == world here,
+    // since the arena centre is the zone origin.
+    public static IReadOnlyList<Waymark> AetherWaymarks =>
+    [
+        new(WaymarkSlot.A,     new Vector3( 20.986f, 0f, -11.020f)),
+        new(WaymarkSlot.B,     new Vector3(  9.315f, 0f,  21.971f)),
+        new(WaymarkSlot.C,     new Vector3(-19.999f, 0f,  11.772f)),
+        new(WaymarkSlot.D,     new Vector3(      0f, 0f,   9.000f)),
+        new(WaymarkSlot.One,   new Vector3(      0f, 0f,  -8.000f)),
+        new(WaymarkSlot.Two,   new Vector3( -8.000f, 0f,   5.000f)),
+        new(WaymarkSlot.Three, new Vector3(  8.000f, 0f,   5.000f)),
+        new(WaymarkSlot.Four,  new Vector3(      0f, 0f,   0.000f)),
+    ];
+
+    public class BNpcBaseId
+    {
+        public const uint BahamutPrime = 0x1FE8;
+        // The fight's generic invisible caster (x42 in the instance): AOE source for
+        // everything the boss doesn't cast from its own body.
+        public const uint Helper = 0x18D6;
+    }
+
+    public class ModelCharaId
+    {
+        // Model 117 variant 4 is what BNpcBase 8168 ships with (P3 Bahamut Prime); variant 3
+        // is the gold skin the boss wears from the Phoenix rebirth on. No BNpcBase pairs with
+        // it, so retail swaps the variant on the same actor and so do we.
+        public const uint GoldenBahamut = 2112;
+    }
+
+    public class BNpcNameId
+    {
+        public const uint BahamutPrime = 3210;
+    }
+
+    public class VfxPath
+    {
+        // The eruption flame. The Exaflare actions carry no VFX row and no AnimationStart, so
+        // the action effect alone renders nothing; retail plays it from the gimmick timeline
+        // they declare as AnimationEnd (mon_sp/gimmick/f1bz_boss_gimmick02), whose VFX this is
+        // (g02 = gimmick02). Spawned on the helper directly.
+        public const string ExaflareEruption = "vfx/monster/gimmick2/eff/f1bz_b0_g02c0i.avfx";
+    }
+
+    public class ActionId
+    {
+        public const uint Exaflare = 9967;       // 0x26EF, boss-body cast, no AOE of its own
+        public const uint ExaflareFirst = 9968;  // 0x26F0, helper, 4.0s cast, arrow omen, 6y circle
+        public const uint ExaflareRest = 9969;   // 0x26F1, helper, instant, 6y circle
+    }
+}

--- a/AnoMech/Scenarios/Ucob/UcobZone.cs
+++ b/AnoMech/Scenarios/Ucob/UcobZone.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Numerics;
+using AnoMech.Core.Game;
+using AnoMech.Core.SimObjects;
+
+namespace AnoMech.Scenarios.Ucob;
+
+public sealed class UcobZone : IZone
+{
+    public static readonly UcobZone Instance = new();
+    // Weather is left at the territory's own (WeatherRate 0 -> row 2); the BGM is the
+    // "Answers" master track, which is what the Golden Bahamut phase plays.
+    public static readonly Phase P5 = new(Instance, "P5", null, 226);
+
+    public string Name => "The Unending Coil of Bahamut";
+    public uint TerritoryId => 733;
+    public Vector3 Origin => new(0f, 0f, 0f);
+    public byte Level => UcobConstants.Level;
+    public ushort ItemLevel => UcobConstants.ItemLevel;
+
+    public IReadOnlyList<WaymarkLayout> WaymarkPresets { get; } =
+        [new WaymarkLayout("Aether Markers", UcobConstants.AetherWaymarks)];
+
+    // The zone loads with its default (P1/P3) arena geometry rather than the Golden Bahamut
+    // floor — dressing each phase correctly means switching whole native layout layers, which
+    // needs engine support this codebase doesn't have yet. Known but not implemented here.
+    //
+    // One layer is suppressed regardless: with no real duty director active, the client-side
+    // load activates every layer at once, so LGB layer 0x1360 (f1b4_t2_jari1 gravel ground
+    // clutter, confirmed live to overlap whatever floor is actually meant to be visible)
+    // z-fights against it — a rapid flicker. This is the one confirmed-safe, narrowly-scoped
+    // fix; it doesn't attempt the rest of the P5 arena look.
+    public void Run(SimWorld world)
+    {
+        world.EnforceArenaBoundary(UcobConstants.Geometry.ArenaRadius);
+        world.Events.Add(1f, () => world.Map.SuppressLayer(0x1360));
+    }
+}

--- a/AnoMech/Windows/MainWindow.cs
+++ b/AnoMech/Windows/MainWindow.cs
@@ -175,7 +175,10 @@ public unsafe class MainWindow : Window, IDisposable
                     {
                         var selected = _selectedScenario == scenario;
                         if (selected) ImGui.PushStyleColor(ImGuiCol.Button, ImGui.GetColorU32(ImGuiCol.ButtonActive));
-                        ImGui.PushID(scenario.Name);
+                        // Zone-qualified: two zones can hold same-named scenarios (UMAD and UCOB
+                        // both have a P5 "Exaflares"), and a shared ImGui id makes the second
+                        // button unclickable.
+                        ImGui.PushID(FullName(scenario));
                         if (ImGui.Button(DisplayName(scenario), new Vector2(-1, 0)))
                             SelectScenario(scenario);
                         ImGui.PopID();


### PR DESCRIPTION
## Summary
- Bahamut Prime's P5 exaflare mechanic for The Unending Coil of Bahamut (Ultimate): six parallel lanes fired as three randomized pairs, with geometry and timing reconstructed from a real clear log rather than guessed.
- Bot strat that holds melee range and steps into a lane once its fire has rolled past.
- Fixes a pre-existing bug where two zones with a same-named scenario (UMAD and UCOB both have a P5 "Exaflares") shared an ImGui id, making the second one's button unclickable.

## Known limitation: arena visual
The arena currently renders with its default (P1/P3) geometry rather than the Golden Bahamut floor. I wasn't able to get this looking correct.

UCOB dresses each phase as whole native LGB layout layers (not `SharedGroup` map-effect states like some other duties in this codebase use), and getting that swap right would need real reverse engineering of an undocumented native "OBSet" system — more than felt safe to attempt live against a running game client (a blind attempt at the related `ProcessMapEffect` mechanism did crash the client once during investigation).

One narrowly-scoped, safe fix is included: LGB layer `0x1360` (P1/P3 gravel ground clutter) visibly z-fights against whatever floor should be showing, since the client-side zone load activates every layer at once with no real duty director selecting the current phase's. That layer is suppressed for the zone's lifetime (`MapController.SuppressLayer`) to stop the flicker, without attempting the rest of the visual.

If anyone has a raw ACT/IINACT network log (not an FFLogs report — those don't expose this) reaching the P4→P5 transition, the exact native effect call retail uses would be in there and could resolve this properly.

## Test plan
- [x] `dotnet build` (Debug and Release) succeeds
- [x] Verified in-game: exaflare geometry/timing against a clear log, bot survival across randomized patterns, gold Bahamut model, waymark preset
- [ ] Arena visual — known incorrect, see above